### PR TITLE
🧵 Kick out redundant `no-shadow` block from `eslint.config.js`

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,6 +1,5 @@
 import {
   default as openreachtechConfig,
-  coreRuleOptionHash,
 } from '@openreachtech/eslint-config'
 
 export default [
@@ -26,21 +25,6 @@ export default [
     ],
     rules: {
       'max-classes-per-file': 'off',
-    },
-  },
-
-  {
-    rules: {
-      'no-shadow': [
-        'error',
-        {
-          allow: [
-            ...coreRuleOptionHash['no-shadow'].allow,
-
-            'require',
-          ],
-        },
-      ],
     },
   },
 ]


### PR DESCRIPTION
# Why

* Close #16