### PR TITLE
🧹 Replace `ai-agent-skills` to `hora-skills`

### DIFF
--- a/kit/agents/hora-digester.md
+++ b/kit/agents/hora-digester.md
@@ -10,7 +10,7 @@ Read **one equipped skill** and write its digest. That one file is your whole ou
 
 ```
 the skill        its name, and its directory under .claude/skills/<skill-name>/
-the version      the @openreachtech/ai-agent-skills version now installed
+the version      the @openreachtech/hora-skills version now installed
 the destination  .hora/digests/<skill-name>.md
 ```
 
@@ -57,7 +57,7 @@ the destination  .hora/digests/<skill-name>.md
 
 ```markdown
 # <skill-name>
-<!-- ai-agent-skills <version> -->
+<!-- hora-skills <version> -->
 <!-- source: .claude/skills/<skill-name>/ -->
 
 **Read the source above whenever this leaves a question open.**

--- a/kit/agents/hora-implementer.md
+++ b/kit/agents/hora-implementer.md
@@ -26,7 +26,7 @@ the scope         the repository to work in, and this feature's bank-id prefix
 
 ## Follow the skills you were handed
 
-**You were handed the names of skills from `@openreachtech/ai-agent-skills`, and those skills hold how the work is actually done.** `/hora-build` holds the order and the exit condition; it deliberately holds no procedure.
+**You were handed the names of skills from `@openreachtech/hora-skills`, and those skills hold how the work is actually done.** `/hora-build` holds the order and the exit condition; it deliberately holds no procedure.
 
 **Each name arrives with a digest — `.hora/digests/<skill-name>.md` — and the digest is where to start.** **Invoke the skill itself through the `Skill` tool the moment a question stays open**: when the digest points you there, when it covers your case thinly, or when what you are about to write is not obviously the thing it describes.
 

--- a/kit/skills/hora-accept/SKILL.md
+++ b/kit/skills/hora-accept/SKILL.md
@@ -13,7 +13,7 @@ Read `../hora/references/structure.md` first. **This skill is strictly read-only
 
 ## What this skill does not contain
 
-**The content of an acceptance review, and the criteria it passes or fails on, are not in this file and must never be written into it.** They live in `@openreachtech/ai-agent-skills`, and this skill delegates the work.
+**The content of an acceptance review, and the criteria it passes or fails on, are not in this file and must never be written into it.** They live in `@openreachtech/hora-skills`, and this skill delegates the work.
 
 | What is needed | Whose it is |
 |---|---|

--- a/kit/skills/hora-build/SKILL.md
+++ b/kit/skills/hora-build/SKILL.md
@@ -151,7 +151,7 @@ Report the decision in one line before starting work — "building #attendance, 
 
 ```
 1. Read the installed version from
-   node_modules/@openreachtech/ai-agent-skills/package.json
+   node_modules/@openreachtech/hora-skills/package.json
 2. For each skill matched above, use .hora/digests/<skill-name>.md while its
    header names that version
 3. For the rest, start hora-digester — one agent per skill, all in one

--- a/kit/skills/hora-build/references/checkpoints.md
+++ b/kit/skills/hora-build/references/checkpoints.md
@@ -2,7 +2,7 @@
 
 **The authority on the checkpoint list.** `/hora-plan` copies the list from here into each feature file; `/hora-build` runs a feature through it.
 
-**This file holds the order and the exit conditions. It holds no procedure.** How to write a migration, a resolver, a component or a test lives in `@openreachtech/ai-agent-skills`, and each checkpoint states the *work* that skill covers (`../../hora/references/structure.md`, "The division of labor").
+**This file holds the order and the exit conditions. It holds no procedure.** How to write a migration, a resolver, a component or a test lives in `@openreachtech/hora-skills`, and each checkpoint states the *work* that skill covers (`../../hora/references/structure.md`, "The division of labor").
 
 **No checkpoint below names a package skill, and none ever may.** Each checkpoint's **Delegate to** row says what has to be covered, and the main session matches that against the equipped skills' own descriptions at run time (`../../hora/references/structure.md`, "No hora file ever names one of those skills"). **Skills Hora Kit itself ships — `/hora-accept`, `bank-id` — are named here freely.**
 

--- a/kit/skills/hora-setup/references/boilerplates.md
+++ b/kit/skills/hora-setup/references/boilerplates.md
@@ -265,7 +265,7 @@ An implementation repository is its own independent git repo, and a standalone c
 cp -r .claude/skills/bank-id <myproject>-backend/.claude/skills/bank-id
 ```
 
-**Never overwrite an existing copy** — skip this step entirely if the destination exists. A human may have customized `bank-id` inside their own backend repository. This is also why it lands directly in the backend row's own `.claude/skills/` rather than coming from `ai-agent-skills`: it has to be reachable, and safely editable, from a session working there directly.
+**Never overwrite an existing copy** — skip this step entirely if the destination exists. A human may have customized `bank-id` inside their own backend repository. This is also why it lands directly in the backend row's own `.claude/skills/` rather than coming from `hora-skills`: it has to be reachable, and safely editable, from a session working there directly.
 
 ### 12. Make an initial commit
 

--- a/kit/skills/hora-spec-backend/SKILL.md
+++ b/kit/skills/hora-spec-backend/SKILL.md
@@ -9,7 +9,7 @@ description: Stage 4 of /hora-spec. Declare the repositories and servers, then d
 
 Read `../hora/references/structure.md` and `../hora-spec/references/principles.md` first. `../hora-spec/references/stages.md` is the authority on this stage's exit condition, `../hora/references/spec-format.md` on the format of every table written here, and `../hora/references/asking.md` on how anything is put to a person.
 
-**This stage holds no design rule of its own.** How a table is shaped, how an SDL is named, where a job belongs and how a queue is tuned all live in `@openreachtech/ai-agent-skills`. Invoke the skills the delegates table names and read them — never restate one of their rules here.
+**This stage holds no design rule of its own.** How a table is shaped, how an SDL is named, where a job belongs and how a queue is tuned all live in `@openreachtech/hora-skills`. Invoke the skills the delegates table names and read them — never restate one of their rules here.
 
 ## What this stage reads
 

--- a/kit/skills/hora-spec-nonfunctional/SKILL.md
+++ b/kit/skills/hora-spec-nonfunctional/SKILL.md
@@ -13,7 +13,7 @@ Read `../hora/references/structure.md` and `../hora-spec/references/principles.m
 
 **Offer numbers as options, never as a blank.** "How many users?" produces a shrug; `200 / 2,000 / 20,000`, with today's row count named alongside, produces an answer in one exchange (`../hora/references/asking.md`).
 
-**Nothing in `@openreachtech/ai-agent-skills` owns this stage, and nothing could.** No skill states what a project's user count or availability target should be. What is written below is which questions to ask; every answer is the requester's.
+**Nothing in `@openreachtech/hora-skills` owns this stage, and nothing could.** No skill states what a project's user count or availability target should be. What is written below is which questions to ask; every answer is the requester's.
 
 ---
 

--- a/kit/skills/hora-spec/references/principles.md
+++ b/kit/skills/hora-spec/references/principles.md
@@ -6,7 +6,7 @@
 
 ## The boundary this file sits on
 
-Hora Kit holds no procedure and no pass/fail criterion that `@openreachtech/ai-agent-skills` already holds (`../../hora/references/structure.md`, "The division of labor"). The line runs like this:
+Hora Kit holds no procedure and no pass/fail criterion that `@openreachtech/hora-skills` already holds (`../../hora/references/structure.md`, "The division of labor"). The line runs like this:
 
 | | Owns | Example |
 |---|---|---|

--- a/kit/skills/hora-spec/references/stages.md
+++ b/kit/skills/hora-spec/references/stages.md
@@ -4,7 +4,7 @@
 
 **Stage 0 is numbered 0 because it does not renumber anything.** It gathers what already exists so that the seven stages have something to correct instead of something to dictate. On a new project it passes in a sentence.
 
-**This file holds the order and the exit conditions. It holds no design rule.** How a table is shaped, how an SDL is named, where a background job belongs and what a screen must account for all live in `@openreachtech/ai-agent-skills` (`../../hora/references/structure.md`, "The division of labor").
+**This file holds the order and the exit conditions. It holds no design rule.** How a table is shaped, how an SDL is named, where a background job belongs and what a screen must account for all live in `@openreachtech/hora-skills` (`../../hora/references/structure.md`, "The division of labor").
 
 **No stage below names a package skill, and none ever may.** Each **Delegate to** row says what has to be covered, and the main session matches that against the equipped skills' own descriptions when it enters the stage (`../../hora/references/structure.md`, "No hora file ever names one of those skills").
 

--- a/kit/skills/hora/SKILL.md
+++ b/kit/skills/hora/SKILL.md
@@ -154,7 +154,7 @@ Report the decision in one line before starting work — for example, "continuin
 
 ## Where the procedures live
 
-**`/hora` holds the order. It holds no procedure and no pass/fail criterion.** How to write a resolver, a migration, a component or a test — and what an acceptance review looks at — all live in `@openreachtech/ai-agent-skills`, equipped under this repository's own `.claude/skills/`.
+**`/hora` holds the order. It holds no procedure and no pass/fail criterion.** How to write a resolver, a migration, a component or a test — and what an acceptance review looks at — all live in `@openreachtech/hora-skills`, equipped under this repository's own `.claude/skills/`.
 
 **Never write one of those procedures into a hora skill** (`references/structure.md`, "The division of labor").
 

--- a/kit/skills/hora/references/structure.md
+++ b/kit/skills/hora/references/structure.md
@@ -15,11 +15,11 @@
 | which repositories exist, and what fills them | Hora Kit | `/hora-setup` |
 | which version is being built, and which features it holds | Hora Kit | `/hora-plan` |
 | **the order of the checkpoints, and each one's exit condition** | Hora Kit | `/hora-build` |
-| **how to write a resolver, a migration, a component, a test** | **`@openreachtech/ai-agent-skills`** | that package's own skills |
-| **how to shape a table, an SDL, a job, a screen** | **`@openreachtech/ai-agent-skills`** | whichever of its skills covers that work |
-| **what an acceptance review looks at, and what it fails on** | **`@openreachtech/ai-agent-skills`** | whichever of its skills covers that work |
+| **how to write a resolver, a migration, a component, a test** | **`@openreachtech/hora-skills`** | that package's own skills |
+| **how to shape a table, an SDL, a job, a screen** | **`@openreachtech/hora-skills`** | whichever of its skills covers that work |
+| **what an acceptance review looks at, and what it fails on** | **`@openreachtech/hora-skills`** | whichever of its skills covers that work |
 
-**Never write a procedure, a convention or a pass/fail criterion into a hora skill when a skill in `ai-agent-skills` already holds it.** State the work and delegate it. A copy disagrees with the original the first time the package is updated, and nothing announces that it has.
+**Never write a procedure, a convention or a pass/fail criterion into a hora skill when a skill in `hora-skills` already holds it.** State the work and delegate it. A copy disagrees with the original the first time the package is updated, and nothing announces that it has.
 
 ### No hora file ever names one of those skills
 

--- a/kit/skills/hora/references/structure.md
+++ b/kit/skills/hora/references/structure.md
@@ -313,7 +313,7 @@ Q4  missing-authorization  blocking: yes
                                 refuses to pass while a row is unrouted
   tree/<repository>.md          what /hora-setup read in the real tree, and the tag it read it at
   digests/<skill-name>.md       one equipped skill's conventions in short form, and the
-                                ai-agent-skills version they were derived from.
+                                hora-skills version they were derived from.
                                 hora-digester writes it. A cache; the skill stays the authority
   tasks/<version>/
     _plan.md                    the feature order, and the acceptance tasks. /hora-plan writes it


### PR DESCRIPTION
# Why

* Close #45

# How

* **Prose, 13 occurrences.** `@openreachtech/ai-agent-skills` → `@openreachtech/hora-skills` wherever a document names the package that holds a procedure, a convention or a pass/fail criterion — `structure.md`'s division-of-labour table, `hora/SKILL.md`, `hora-accept`, the `hora-spec` stages, `hora-build`'s checkpoints, `hora-implementer`, `boilerplates.md`.

* **The path `hora-build` reads, 1 occurrence.** `node_modules/@openreachtech/hora-skills/package.json`. This is the version the digest freshness check compares against, so it is the one occurrence that changes behaviour rather than wording.

* **The digest marker, 3 occurrences.** `hora-digester` now writes `<!-- hora-skills <version> -->`, and `structure.md`'s description of that record follows it. Digests already written under the old spelling keep it; they are rewritten on the next version change either way.

* Three commits, one per kind. The diff is `-17 / +17` across 12 files, with no other change.

* Cut from the equipping retirement, so this branch shows only its own three commits once that one has landed.

* `npm test` — 259 passed. `npm run lint` — clean. `grep` confirms no occurrence of the old name remains under `kit/`.