### PR TITLE
⚙️ Add `engines:` as node version 20 or later

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22,6 +22,9 @@
         "@types/jest": "^30.0.0",
         "eslint": "^9.39.5",
         "jest": "^30.4.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
       }
     },
     "node_modules/@babel/code-frame": {

--- a/package.json
+++ b/package.json
@@ -33,6 +33,9 @@
     "url": "https://github.com/openreachtech/hora-core/issues"
   },
   "homepage": "https://github.com/openreachtech/hora-core#readme",
+  "engines": {
+    "node": ">=20.0.0"
+  },
   "dependencies": {
   },
   "devDependencies": {


### PR DESCRIPTION
# Why

* Close #50