### PR TITLE
🐛 Keep an installation's removal inside the installation directory

### DIFF
--- a/lib/equip/HoraCoreInstaller.js
+++ b/lib/equip/HoraCoreInstaller.js
@@ -143,6 +143,33 @@ export default class HoraCoreInstaller {
   }
 
   /**
+   * Tell whether an entry name addresses an entry directly inside an installation directory.
+   *
+   * An entry name is one name of one entry — a skill directory or an agent file — so it
+   * never carries a path. Reading one that does would let a manifest of the consuming
+   * repository name a path outside the installation directory, and a removal follows what
+   * the manifest names.
+   *
+   * The separators of both platforms are refused, rather than the one this platform uses,
+   * so that a manifest written on either is read the same way on either.
+   *
+   * @param {{
+   *   entryName: string
+   * }} params - Parameters.
+   * @returns {boolean} Whether the entry name addresses an entry of an installation directory.
+   * @public
+   */
+  static isPlainEntryName ({
+    entryName,
+  }) {
+    return entryName !== ''
+      && entryName !== '.'
+      && entryName !== '..'
+      && !entryName.includes('/')
+      && !entryName.includes('\\')
+  }
+
+  /**
    * Constructor of this instance.
    *
    * @returns {typeof HoraCoreInstaller} Constructor of this instance.
@@ -221,6 +248,10 @@ export default class HoraCoreInstaller {
    * replaced. An entry named after nothing this package distributes is left alone, which
    * is what keeps a skill the consuming repository authored out of the removal.
    *
+   * What the manifest records is read as a claim rather than as a fact, so a name that
+   * does not address an entry of the installation directory is dropped before anything
+   * is removed.
+   *
    * @returns {Array<string>} Entry names to remove.
    */
   collectRemovableEntryNames () {
@@ -230,6 +261,7 @@ export default class HoraCoreInstaller {
         ...this.collectDistributedEntryNamesInTarget(),
       ]),
     ]
+      .filter(it => this.Ctor.isPlainEntryName({ entryName: it }))
       .toSorted()
   }
 

--- a/lib/equip/HoraCoreManifestFile.js
+++ b/lib/equip/HoraCoreManifestFile.js
@@ -85,13 +85,22 @@ export default class HoraCoreManifestFile {
   /**
    * Load the entry names recorded for this installation directory by the previous run.
    *
-   * @returns {Array<string>} Recorded entry names, empty when nothing is recorded.
+   * The manifest sits in the consuming repository, so what it holds is not guaranteed to
+   * be what a previous run wrote. Anything but an array of strings is read as nothing
+   * recorded, and a member that is not a string is dropped from the ones that are.
+   *
+   * @returns {Array<string>} Recorded entry names, empty when nothing usable is recorded.
    * @public
    */
   loadEntryNames () {
-    return this.loadInstallation()
+    const entryNames = this.loadInstallation()
       ?.entryNames
-      ?? []
+
+    if (!Array.isArray(entryNames)) {
+      return []
+    }
+
+    return entryNames.filter(it => typeof it === 'string')
   }
 
   /**

--- a/tests/__tests__/equip/HoraCoreInstaller.js
+++ b/tests/__tests__/equip/HoraCoreInstaller.js
@@ -312,6 +312,89 @@ describe('HoraCoreInstaller', () => {
 })
 
 describe('HoraCoreInstaller', () => {
+  describe('.isPlainEntryName()', () => {
+    describe('should be true for an entry of the installation directory', () => {
+      const cases = [
+        {
+          input: {
+            entryName: 'hora-plan',
+          },
+        },
+        {
+          input: {
+            entryName: 'hora-verifier.md',
+          },
+        },
+        {
+          input: {
+            entryName: '.hidden-skill',
+          },
+        },
+        {
+          input: {
+            entryName: 'skill with space',
+          },
+        },
+      ]
+
+      test.each(cases)('entryName: $input.entryName', ({ input }) => {
+        const received = HoraCoreInstaller.isPlainEntryName(input)
+
+        expect(received)
+          .toBe(true)
+      })
+    })
+
+    describe('should be false for an entry name reaching outside the installation directory', () => {
+      const cases = [
+        {
+          input: {
+            entryName: '..',
+          },
+        },
+        {
+          input: {
+            entryName: '.',
+          },
+        },
+        {
+          input: {
+            entryName: '',
+          },
+        },
+        {
+          input: {
+            entryName: '../../../canary',
+          },
+        },
+        {
+          input: {
+            entryName: 'hora-plan/SKILL.md',
+          },
+        },
+        {
+          input: {
+            entryName: '/etc/hosts',
+          },
+        },
+        {
+          input: {
+            entryName: '..\\..\\canary',
+          },
+        },
+      ]
+
+      test.each(cases)('entryName: $input.entryName', ({ input }) => {
+        const received = HoraCoreInstaller.isPlainEntryName(input)
+
+        expect(received)
+          .toBe(false)
+      })
+    })
+  })
+})
+
+describe('HoraCoreInstaller', () => {
   describe('#get:fs', () => {
     describe('when called as is', () => {
       test('should be fixed value', () => {
@@ -611,6 +694,49 @@ describe('HoraCoreInstaller', () => {
           .toEqual(expected)
       })
     })
+
+    describe('should never remove outside the installation directory', () => {
+      const cases = [
+        {
+          override: {
+            recordedEntryNames: [
+              '../../../canary',
+              'hora-plan',
+            ],
+          },
+          expected: [
+            [
+              '/consumer/.claude/skills/hora-plan',
+              {
+                recursive: true,
+                force: true,
+              },
+            ],
+          ],
+        },
+      ]
+
+      test.each(cases)('recordedEntryNames: $override.recordedEntryNames', ({ override, expected }) => {
+        const installer = HoraCoreInstaller.create({
+          workingDirectoryPath: '/consumer',
+          targetDirectoryPath: '/consumer/.claude/skills',
+          sourceDirectoryPath: '/package/dist/skills',
+        })
+
+        jest.spyOn(installer.manifestFile, 'loadEntryNames')
+          .mockReturnValue(override.recordedEntryNames)
+
+        const rmSyncSpy = jest.spyOn(fs, 'rmSync')
+          .mockReturnValue()
+
+        installer.removeInstalledEntries()
+
+        expect(rmSyncSpy)
+          .toHaveBeenCalledTimes(1)
+        expect(rmSyncSpy)
+          .toHaveBeenNthCalledWith(1, ...expected[0])
+      })
+    })
   })
 })
 
@@ -660,6 +786,57 @@ describe('HoraCoreInstaller', () => {
             targetEntryNames: [
               'hora-own-skill',
             ],
+          },
+          expected: [],
+        },
+      ]
+
+      test.each(cases)('recordedEntryNames: $override.recordedEntryNames', ({ override, expected }) => {
+        const installer = HoraCoreInstaller.create({
+          workingDirectoryPath: '/consumer',
+          targetDirectoryPath: '/consumer/.claude/skills',
+          sourceDirectoryPath: '/package/dist/skills',
+        })
+
+        jest.spyOn(installer.manifestFile, 'loadEntryNames')
+          .mockReturnValue(override.recordedEntryNames)
+        jest.spyOn(installer, 'collectDistributedEntryNames')
+          .mockReturnValue(override.distributedEntryNames)
+        jest.spyOn(installer, 'collectEntryNames')
+          .mockReturnValue(override.targetEntryNames)
+
+        const received = installer.collectRemovableEntryNames()
+
+        expect(received)
+          .toEqual(expected)
+      })
+    })
+
+    describe('should drop a recorded entry name that is not a plain entry name', () => {
+      const cases = [
+        {
+          override: {
+            recordedEntryNames: [
+              'hora-plan',
+              '../../../canary',
+            ],
+            distributedEntryNames: [],
+            targetEntryNames: [],
+          },
+          expected: [
+            'hora-plan',
+          ],
+        },
+        {
+          override: {
+            recordedEntryNames: [
+              '..',
+              '.',
+              '',
+              'hora-plan/SKILL.md',
+            ],
+            distributedEntryNames: [],
+            targetEntryNames: [],
           },
           expected: [],
         },

--- a/tests/__tests__/equip/HoraCoreManifestFile.js
+++ b/tests/__tests__/equip/HoraCoreManifestFile.js
@@ -289,6 +289,109 @@ describe('HoraCoreManifestFile', () => {
           .toEqual([])
       })
     })
+
+    describe('should be empty when the recorded entryNames is not an array', () => {
+      const cases = [
+        {
+          override: {
+            entryNames: 'hora-plan',
+          },
+        },
+        {
+          override: {
+            entryNames: 1,
+          },
+        },
+        {
+          override: {
+            entryNames: null,
+          },
+        },
+        {
+          override: {
+            entryNames: {
+              0: 'hora-plan',
+            },
+          },
+        },
+      ]
+
+      test.each(cases)('entryNames: $override.entryNames', ({ override }) => {
+        const manifestFile = HoraCoreManifestFile.create({
+          filePath: '/tmp/app/.hora/equip-core.json',
+          installationPath: '.claude/skills',
+        })
+
+        jest.spyOn(manifestFile, 'load')
+          .mockReturnValue({
+            version: '0.0.1',
+            installations: {
+              '.claude/skills': {
+                entryNames: override.entryNames,
+              },
+            },
+          })
+
+        const received = manifestFile.loadEntryNames()
+
+        expect(received)
+          .toEqual([])
+      })
+    })
+
+    describe('should keep only the recorded entry names that are strings', () => {
+      const cases = [
+        {
+          override: {
+            entryNames: [
+              'hora-plan',
+              1,
+              'hora-spec',
+            ],
+          },
+          expected: [
+            'hora-plan',
+            'hora-spec',
+          ],
+        },
+        {
+          override: {
+            entryNames: [
+              null,
+              {
+                entryName: 'hora-plan',
+              },
+              [
+                'hora-plan',
+              ],
+            ],
+          },
+          expected: [],
+        },
+      ]
+
+      test.each(cases)('entryNames: $override.entryNames', ({ override, expected }) => {
+        const manifestFile = HoraCoreManifestFile.create({
+          filePath: '/tmp/app/.hora/equip-core.json',
+          installationPath: '.claude/skills',
+        })
+
+        jest.spyOn(manifestFile, 'load')
+          .mockReturnValue({
+            version: '0.0.1',
+            installations: {
+              '.claude/skills': {
+                entryNames: override.entryNames,
+              },
+            },
+          })
+
+        const received = manifestFile.loadEntryNames()
+
+        expect(received)
+          .toEqual(expected)
+      })
+    })
   })
 })
 


### PR DESCRIPTION
# Why

* Close #52

## No published version is affected

* `0.0.0` publishes `dist/` alone — no `bin`, no `postinstall`, no `lib/` — so the installer and the defect both arrive in `0.1.0`, which is still unpublished.

# How

## The guard

* Add `HoraCoreInstaller.isPlainEntryName()`, telling whether a name addresses an entry directly inside an installation directory, and filter `#collectRemovableEntryNames()` through it. A recorded `../../../anything` is dropped before `path.join()` sees it, so `fs.rmSync()` is never handed a path outside the installation directory.
* Refuse both `/` and `\`, rather than the separator of the running platform, so that a manifest written on either platform is read the same way on either.
* Read a recorded `entryNames` that is not an array of strings as nothing recorded, in `HoraCoreManifestFile#loadEntryNames()`. A string used to spread into its characters, and each character was then a name to remove.
* Leave the key of `installations` unchecked. It is a path relative to the working directory and legitimately carries `..` when `--dir` points above it, which `.buildInstallationPath()`'s own test already covers.

## Tests

* `.isPlainEntryName()`: the names it passes, and `..`, `.`, the empty string, `../../../canary`, `hora-plan/SKILL.md`, `/etc/hosts`, `..\..\canary`.
* `#collectRemovableEntryNames()`: a recorded name carrying a path is dropped, the plain ones survive.
* `#removeInstalledEntries()`: `fs.rmSync` is called for the plain name alone, never for the one reaching outside.
* `#loadEntryNames()`: `entryNames` that is not an array reads as nothing recorded, and a member that is not a string is dropped.

## Verified against a packed tarball

* Installing into a repository whose `.hora/equip-core.json` names `../../../canary` now leaves that path in place. Before this branch, `npm install` removed it and reported only `Removed 1 entries from <repo>/.claude/skills`.
* A normal install still places 14 skills and 3 agents, `hora-core install` is still repeatable, `hora-core uninstall` still removes the distributed entries alone, and a skill the consuming repository authored survives all of them.

## Left out

* An installation directory that is itself a symbolic link. Symlinking `.claude` is something a repository may do on purpose, and what an installation writes through one is this package's own payload, so it is a behaviour change to weigh on its own.