### PR TITLE
💪 Enhance the report of what a command raises

### DIFF
--- a/lib/equip/HoraCoreCli.js
+++ b/lib/equip/HoraCoreCli.js
@@ -90,21 +90,49 @@ export default class HoraCoreCli {
     env = process.env,
     logger = console,
   } = {}) {
-    if (this.isOwnRepository({ env })) {
-      return 0
-    }
-
-    const exitCode = this.createForPostinstall({
+    const exitCode = this.runPostinstallCommand({
       env,
       logger,
     })
-      .run()
 
     if (exitCode !== 0) {
       logger.error('The kit was not installed. Run `npx hora-core install` once the above is settled.')
     }
 
     return 0
+  }
+
+  /**
+   * Run the install of the `postinstall`, reporting whatever it raises.
+   *
+   * `run()` reports what a command raises, so this catches what is raised around it —
+   * reading the repository's own `package.json`, or building the command at all.
+   *
+   * @param {{
+   *   env: Record<string, string | undefined>
+   *   logger: Console
+   * }} params - Parameters.
+   * @returns {number} Exit code.
+   */
+  static runPostinstallCommand ({
+    env,
+    logger,
+  }) {
+    try {
+      if (this.isOwnRepository({ env })) {
+        return 0
+      }
+
+      return this.createForPostinstall({
+        env,
+        logger,
+      })
+        .run()
+    } catch (error) {
+      logger.error(this.buildFailureMessage({ error }))
+
+      return 1
+    }
   }
 
   /**

--- a/lib/equip/HoraCoreCli.js
+++ b/lib/equip/HoraCoreCli.js
@@ -266,6 +266,52 @@ export default class HoraCoreCli {
   }
 
   /**
+   * Build the line a failure is reported as.
+   *
+   * A message names the path the failure happened on, and a path can carry an entry name
+   * the consuming repository chose, so the characters a terminal acts on are dropped
+   * before the line reaches one. Everything a path may legitimately hold is kept.
+   *
+   * @param {{
+   *   error: unknown
+   * }} params - Parameters.
+   * @returns {string} Line reporting the failure.
+   */
+  static buildFailureMessage ({
+    error,
+  }) {
+    const message = error instanceof Error
+      ? error.message
+      : String(error)
+
+    return [
+      ...message,
+    ]
+      .map(it => this.buildPrintableCharacter({ character: it }))
+      .join('')
+  }
+
+  /**
+   * Build the character a terminal prints in place of one it would act on.
+   *
+   * @param {{
+   *   character: string
+   * }} params - Parameters.
+   * @returns {string} The character itself, or the one standing for it.
+   */
+  static buildPrintableCharacter ({
+    character,
+  }) {
+    const codePoint = character.codePointAt(0)
+
+    if (codePoint >= 0x20 && codePoint !== 0x7f) {
+      return character
+    }
+
+    return '?'
+  }
+
+  /**
    * Usage text.
    *
    * @returns {string} Usage text.
@@ -371,12 +417,30 @@ export default class HoraCoreCli {
   }
 
   /**
-   * Run the command.
+   * Run the command, reporting whatever it raises.
+   *
+   * A command reaches the file system of a repository this package knows nothing about, so
+   * a failure it cannot help is ordinary: a payload directory that is a file, a `.claude/`
+   * that is read only, a disk with nothing left. None of them is worth a stack trace, and
+   * none of them may escape — the `postinstall` promises `npm install` a successful run.
    *
    * @returns {number} Exit code.
    * @public
    */
   run () {
+    try {
+      return this.dispatch()
+    } catch (error) {
+      return this.reportFailure({ error })
+    }
+  }
+
+  /**
+   * Dispatch to the command.
+   *
+   * @returns {number} Exit code.
+   */
+  dispatch () {
     const command = this.commandLineArguments.extractCommand()
       ?? CLI_COMMAND.HELP
 
@@ -666,6 +730,22 @@ export default class HoraCoreCli {
       })
 
     return 0
+  }
+
+  /**
+   * Report a failure raised while a command ran.
+   *
+   * @param {{
+   *   error: unknown
+   * }} params - Parameters.
+   * @returns {number} Exit code.
+   */
+  reportFailure ({
+    error,
+  }) {
+    this.logger.error(this.Ctor.buildFailureMessage({ error }))
+
+    return 1
   }
 
   /**

--- a/tests/__tests__/equip/HoraCoreCli.js
+++ b/tests/__tests__/equip/HoraCoreCli.js
@@ -316,6 +316,43 @@ describe('HoraCoreCli', () => {
           .toHaveBeenCalledWith('The kit was not installed. Run `npx hora-core install` once the above is settled.')
       })
     })
+
+    describe('should end successfully on a raised failure', () => {
+      const cases = [
+        {
+          override: {
+            error: new Error('ENOTDIR: not a directory, scandir \'/consumer/.claude/agents\''),
+          },
+          expected: 'The kit was not installed. Run `npx hora-core install` once the above is settled.',
+        },
+      ]
+
+      test.each(cases)('error: $override.error.message', ({ override, expected }) => {
+        jest.spyOn(HoraCoreCli, 'isOwnRepository')
+          .mockReturnValue(false)
+        jest.spyOn(HoraCoreCli.prototype, 'run')
+          .mockImplementation(() => {
+            throw override.error
+          })
+
+        const errorSpy = jest.fn()
+
+        const received = HoraCoreCli.runPostinstall({
+          env: {
+            npm_config_local_prefix: '/consumer',
+          },
+          logger: {
+            log: () => {},
+            error: errorSpy,
+          },
+        })
+
+        expect(received)
+          .toBe(0)
+        expect(errorSpy)
+          .toHaveBeenCalledWith(expected)
+      })
+    })
   })
 })
 
@@ -600,7 +637,7 @@ describe('HoraCoreCli', () => {
 })
 
 describe('HoraCoreCli', () => {
-  describe('#run()', () => {
+  describe('#dispatch()', () => {
     describe('should dispatch to the command', () => {
       const cases = [
         {
@@ -656,7 +693,7 @@ describe('HoraCoreCli', () => {
         const commandSpy = jest.spyOn(cli, expected)
           .mockReturnValue(0)
 
-        cli.run()
+        cli.dispatch()
 
         expect(commandSpy)
           .toHaveBeenCalledWith()
@@ -849,6 +886,334 @@ describe('HoraCoreCli', () => {
         expect(installSpy)
           .not
           .toHaveBeenCalled()
+      })
+    })
+  })
+})
+
+describe('HoraCoreCli', () => {
+  describe('#run()', () => {
+    describe('should report what a command raises, instead of letting it escape', () => {
+      const cases = [
+        {
+          override: {
+            error: new Error('ENOTDIR: not a directory, scandir \'/consumer/.claude/agents\''),
+          },
+          expected: 'ENOTDIR: not a directory, scandir \'/consumer/.claude/agents\'',
+        },
+        {
+          override: {
+            error: new Error('EACCES: permission denied, mkdir \'/consumer/.claude/skills\''),
+          },
+          expected: 'EACCES: permission denied, mkdir \'/consumer/.claude/skills\'',
+        },
+      ]
+
+      test.each(cases)('error: $override.error.message', ({ override, expected }) => {
+        const logger = {
+          log: jest.fn(),
+          error: jest.fn(),
+        }
+        const cli = HoraCoreCli.create({
+          args: [
+            'install',
+          ],
+          workingDirectoryPath: '/consumer',
+          logger,
+        })
+
+        jest.spyOn(cli, 'dispatch')
+          .mockImplementation(() => {
+            throw override.error
+          })
+
+        const received = cli.run()
+
+        expect(received)
+          .toBe(1)
+        expect(logger.error)
+          .toHaveBeenCalledWith(expected)
+      })
+    })
+
+    describe('should be the exit code of the command it dispatched', () => {
+      const cases = [
+        {
+          override: {
+            exitCode: 0,
+          },
+        },
+        {
+          override: {
+            exitCode: 1,
+          },
+        },
+      ]
+
+      test.each(cases)('exitCode: $override.exitCode', ({ override }) => {
+        const cli = HoraCoreCli.create({
+          args: [
+            'install',
+          ],
+          workingDirectoryPath: '/consumer',
+        })
+
+        jest.spyOn(cli, 'dispatch')
+          .mockReturnValue(override.exitCode)
+
+        const received = cli.run()
+
+        expect(received)
+          .toBe(override.exitCode)
+      })
+    })
+  })
+})
+
+describe('HoraCoreCli', () => {
+  describe('#reportFailure()', () => {
+    describe('should report the failure and fail', () => {
+      const cases = [
+        {
+          input: {
+            error: new Error('EROFS: read-only file system'),
+          },
+          expected: 'EROFS: read-only file system',
+        },
+      ]
+
+      test.each(cases)('error: $input.error.message', ({ input, expected }) => {
+        const logger = {
+          log: jest.fn(),
+          error: jest.fn(),
+        }
+        const cli = HoraCoreCli.create({
+          args: [
+            'install',
+          ],
+          workingDirectoryPath: '/consumer',
+          logger,
+        })
+
+        const received = cli.reportFailure(input)
+
+        expect(received)
+          .toBe(1)
+        expect(logger.error)
+          .toHaveBeenCalledWith(expected)
+      })
+    })
+  })
+})
+
+describe('HoraCoreCli', () => {
+  describe('.buildFailureMessage()', () => {
+    describe('should be the message of the error', () => {
+      const cases = [
+        {
+          input: {
+            error: new Error('EACCES: permission denied'),
+          },
+          expected: 'EACCES: permission denied',
+        },
+        {
+          input: {
+            error: new Error('ENOENT: no such file, open \'/consumer/.claude/スキル\''),
+          },
+          expected: 'ENOENT: no such file, open \'/consumer/.claude/スキル\'',
+        },
+      ]
+
+      test.each(cases)('error: $input.error.message', ({ input, expected }) => {
+        const received = HoraCoreCli.buildFailureMessage(input)
+
+        expect(received)
+          .toBe(expected)
+      })
+    })
+
+    describe('should drop the characters a terminal acts on', () => {
+      const cases = [
+        {
+          input: {
+            error: new Error('EACCES: denied, rm \'/consumer/.claude/skills/\u001b[2Jhora\''),
+          },
+          expected: 'EACCES: denied, rm \'/consumer/.claude/skills/?[2Jhora\'',
+        },
+        {
+          input: {
+            error: new Error('ENOENT: no such file\u0000\u007f'),
+          },
+          expected: 'ENOENT: no such file??',
+        },
+      ]
+
+      test.each(cases)('error: $input.error.message', ({ input, expected }) => {
+        const received = HoraCoreCli.buildFailureMessage(input)
+
+        expect(received)
+          .toBe(expected)
+      })
+    })
+
+    describe('should be the value itself when it is not an error', () => {
+      const cases = [
+        {
+          input: {
+            error: 'raised a string',
+          },
+          expected: 'raised a string',
+        },
+        {
+          input: {
+            error: null,
+          },
+          expected: 'null',
+        },
+      ]
+
+      test.each(cases)('error: $input.error', ({ input, expected }) => {
+        const received = HoraCoreCli.buildFailureMessage(input)
+
+        expect(received)
+          .toBe(expected)
+      })
+    })
+  })
+})
+
+describe('HoraCoreCli', () => {
+  describe('.buildPrintableCharacter()', () => {
+    describe('should be the character itself when a terminal prints it', () => {
+      const cases = [
+        {
+          input: {
+            character: 'a',
+          },
+        },
+        {
+          input: {
+            character: ' ',
+          },
+        },
+        {
+          input: {
+            character: 'ス',
+          },
+        },
+      ]
+
+      test.each(cases)('character: $input.character', ({ input }) => {
+        const received = HoraCoreCli.buildPrintableCharacter(input)
+
+        expect(received)
+          .toBe(input.character)
+      })
+    })
+
+    describe('should stand in for the character when a terminal acts on it', () => {
+      const cases = [
+        {
+          input: {
+            character: '\u001b',
+          },
+        },
+        {
+          input: {
+            character: '\u0000',
+          },
+        },
+        {
+          input: {
+            character: '\u007f',
+          },
+        },
+        {
+          input: {
+            character: '\n',
+          },
+        },
+      ]
+
+      test.each(cases)('codePoint: $input.character.codePointAt', ({ input }) => {
+        const received = HoraCoreCli.buildPrintableCharacter(input)
+
+        expect(received)
+          .toBe('?')
+      })
+    })
+  })
+})
+
+describe('HoraCoreCli', () => {
+  describe('.runPostinstallCommand()', () => {
+    describe('should report what building or running the command raises', () => {
+      const cases = [
+        {
+          override: {
+            error: new Error('EACCES: permission denied, open \'/consumer/package.json\''),
+          },
+          expected: 'EACCES: permission denied, open \'/consumer/package.json\'',
+        },
+      ]
+
+      test.each(cases)('error: $override.error.message', ({ override, expected }) => {
+        jest.spyOn(HoraCoreCli, 'isOwnRepository')
+          .mockImplementation(() => {
+            throw override.error
+          })
+
+        const errorSpy = jest.fn()
+
+        const received = HoraCoreCli.runPostinstallCommand({
+          env: {
+            npm_config_local_prefix: '/consumer',
+          },
+          logger: {
+            log: () => {},
+            error: errorSpy,
+          },
+        })
+
+        expect(received)
+          .toBe(1)
+        expect(errorSpy)
+          .toHaveBeenCalledWith(expected)
+      })
+    })
+
+    describe('should be the exit code of the command', () => {
+      const cases = [
+        {
+          override: {
+            exitCode: 0,
+          },
+        },
+        {
+          override: {
+            exitCode: 1,
+          },
+        },
+      ]
+
+      test.each(cases)('exitCode: $override.exitCode', ({ override }) => {
+        jest.spyOn(HoraCoreCli, 'isOwnRepository')
+          .mockReturnValue(false)
+        jest.spyOn(HoraCoreCli.prototype, 'run')
+          .mockReturnValue(override.exitCode)
+
+        const received = HoraCoreCli.runPostinstallCommand({
+          env: {
+            npm_config_local_prefix: '/consumer',
+          },
+          logger: {
+            log: () => {},
+            error: () => {},
+          },
+        })
+
+        expect(received)
+          .toBe(override.exitCode)
       })
     })
   })


### PR DESCRIPTION
# Why

* Close #57

## The half that #54 did not cover

* The branch before this one made a command refuse to follow a symbolic link, and that refusal ends cleanly because it is carried in a return value. An exception is not, and passes straight through the two lines that read one. This is the other half: nothing a command raises reaches npm.

# How

## The report

* Move the dispatch out of `run()` into `#dispatch()`, and have `run()` call it inside a `try`. A command reaches the file system of a repository this package knows nothing about, so a failure it cannot help is ordinary, and is reported as one line and exit code 1 rather than as a stack trace.
* Add `#reportFailure()` and `.buildFailureMessage()`. A message is the error's own where there is one, and the value itself where there is not.
* Drop the characters a terminal acts on, through `.buildPrintableCharacter()`. A message names the path it failed on, and a path can carry an entry name the consuming repository chose, so an escape sequence could ride out on it. Everything a path may legitimately hold, `スキル` included, is kept.

## The postinstall

* Add `.runPostinstallCommand()`, catching what is raised around a command as well as inside it — reading the repository's own `package.json` through `isOwnRepository()`, or building the command at all.
* `.runPostinstall()` now returns zero whatever happens, which is what its own documentation has claimed all along. A failure reaches the person as the sentence that was already there: `The kit was not installed. Run \`npx hora-core install\` once the above is settled.`

## Tests

* `.buildFailureMessage()` and `.buildPrintableCharacter()`: an error's message, a value that is not an error, a message carrying `\u001b[2J`, and one carrying a Japanese path.
* `#run()`: the exit code of what it dispatched, and 1 with one reported line where the dispatch raised.
* `.runPostinstallCommand()`: the exit code of the command, and 1 with one reported line where building it raised.
* `.runPostinstall()`: zero even where the command raised, with the guidance printed.
* The dispatch cases move from `#run()` to `#dispatch()`, unchanged.

## Verified against a packed tarball

* A repository holding a plain file named `.claude/agents`: `npm install` now exits 0 with no npm error at all, and the package stays installed, where before it exited 1 and npm rolled the package back. `npx hora-core install` then reports `ENOTDIR: not a directory, scandir '<repo>/.claude/agents'` and exits 1.
* A repository whose `.claude/` is read only: the same, reporting `EACCES: permission denied, mkdir '<repo>/.claude/agents'`.
* 327 tests pass.

## Left out

* The half-written installation. `install` is repeatable, so a second run finishes what the first could not, and a transaction is not worth its weight for a copy of a fixed payload.
* Refusing a payload path that is neither absent nor a directory. It would read better than an `ENOTDIR`, but it is a rule about what a command writes into — the subject of #54's branch, not this one.