### PR TITLE
📄 Replace the LTS wording with the version engines declares

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -20,7 +20,7 @@ Hora 自体の仕組み — このキットが運ぶ手法 — はボイラー�
 
 ## インストール
 
-Node.js の現行 LTS が必要です（CI がビルド対象とするバージョン）。
+Node.js 20.0.0 以降が必要です（`package.json` の `engines` が宣言している下限）。CI は現行の LTS でビルドしています。
 
 ```sh
 npm install -D @openreachtech/hora

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ How Hora itself works — the method this kit carries — is documented with the
 
 ## Installation
 
-Requires the current Node.js LTS (the version the CI builds against).
+Requires Node.js 20.0.0 or newer, the floor `engines` declares. The CI builds against the current LTS.
 
 ```sh
 npm install -D @openreachtech/hora


### PR DESCRIPTION
# Why

* Close #59

# How

* `README.md` opens its installation section with the floor as a number, named as the same thing `package.json` declares:

```diff
-Requires the current Node.js LTS (the version the CI builds against).
+Requires Node.js 20.0.0 or newer, the floor `engines` declares. The CI builds against the current LTS.
```

* `README.ja.md` takes the same line, in its own commit, since the two files run line for line:

```diff
-Node.js の現行 LTS が必要です（CI がビルド対象とするバージョン）。
+Node.js 20.0.0 以降が必要です（`package.json` の `engines` が宣言している下限）。CI は現行の LTS でビルドしています。
```

* The CI's version stays, as a sentence of its own rather than as the requirement. What `engines` allows and what `test.yml` exercises are two facts, and the old line spent one sentence on both.
* Nothing outside the two lines changes: no code, no `engines`, no workflow.