### PR TITLE
⚙️ Update package version to `0.2.1`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@openreachtech/hora",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@openreachtech/hora",
-      "version": "0.2.0",
+      "version": "0.2.1",
       "license": "Apache-2.0",
       "bin": {
         "hora-core": "lib/equip/hora-core.js"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openreachtech/hora",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "Hora Kit: a package that distributes AI skills, agents, and docs for AI-driven application development.",
   "type": "module",
   "files": [


### PR DESCRIPTION
Bump the package version from `0.2.0` to `0.2.1`, in `package.json` and in the two version fields of `package-lock.json`, ahead of publishing to npmjs.

Close #88