### PR TITLE
Stack separation, phase 2: the spec format and stages name no stack

### DIFF
--- a/kit/skills/hora-plan/SKILL.md
+++ b/kit/skills/hora-plan/SKILL.md
@@ -233,7 +233,7 @@ Work through the resolved document and check every one of these.
 | **An order that puts every feature after the features it depends on** | `/hora-build` silently builds them in a different order than the document states | **yes** |
 | The implementation scope, split into "for now" and "permanently" | the design cannot tell an extension point from a dead abstraction | yes |
 | Whether existing assets may be used | "reimplement" is implied, but whether the code is visible is unknown | yes |
-| Unknown fields in an SDL or a REST payload | it would mean inventing the shape of an API | yes |
+| Unknown fields in an API schema or a REST payload | it would mean inventing the shape of an API | yes |
 | A contradiction in the text | there is no way to choose between them | yes |
 | `baseline: inventoried` under `Baseline: verified` | the permission was never granted | yes |
 | `baseline: inventoried` with no `built:` | nothing makes "this code exists" checkable | yes |
@@ -317,7 +317,7 @@ whether an extension point should be left in place.
 | `contradiction` | a contradiction in the text | yes |
 | `dependency-install` | a declared dependency failed to install, or a conflict-proof change failed to apply | yes |
 | `lacked-environment` | something failed for a reason no code change could fix | yes |
-| `undefined-detail` | undefined types, SDL, zod definitions, seed values and the like | depends |
+| `undefined-detail` | undefined types, schema or validation definitions, seed values and the like | depends |
 | `common-file` | undocumented handwritten content mixed into a file several features share | depends |
 | `inferred-annotation` | reporting that `id` / `target` / `depends` was inferred | no |
 | `spec-assumption` | an ambiguous criterion was still meetable under some reading; one was assumed and judged against | no |
@@ -338,7 +338,7 @@ Write them into `.hora/contracts/<version>/`.
 
 **The largest risk of having split into repositories is contract drift.** Let each repository derive its schema from the spec independently and they will disagree. Derive once before implementing, pin it, and have every side read that.
 
-The spec's GraphQL / REST tables usually already carry schema names, inputs and results. **When there is no actual SDL:**
+The spec's API tables usually already carry schema names, inputs and results. **When there is no actual schema definition:**
 
 ```
 RpaFlowsInput(pagination)    the contents are indicated in parentheses
@@ -357,16 +357,18 @@ RpaFlowsInput                the fields are unknown
 
 ```
 .hora/contracts/1.0.0/
-  employee-graphql.graphql
-  admin-graphql.graphql
-  public-rest.md
+  employee-api.<ext>
+  admin-api.<ext>
+  public-rest.<ext>
 ```
+
+**The file form of each contract — its extension and what it holds — is the stack handbook's** (`docs/stack/artifacts.md`, "The contract a server's consumers read"), decided by the server's protocol.
 
 **A contract is only made for a server whose consumer is in another repository or outside.** The declaration's `consumer` column decides it.
 
 | Server | Consumer | Contract |
 |---|---|---|
-| `employee-graphql` | `frontend-employee` (another repository) | **needed** |
+| `employee-api` | `frontend-employee` (another repository) | **needed** |
 | `public-rest` | the phone app (outside) | **needed** |
 | `worker` | an API server in the same repository | **not needed** |
 
@@ -523,7 +525,7 @@ Twenty sections carry `built:` and three of them are listed, so seventeen entrie
 <!-- spec: attendance @ sha256:abc123... -->
 <!-- repositories: backend, frontend-employee -->
 
-Constraint: this will be reindexed into Elasticsearch later (#search-infra).
+Constraint: this will be reindexed into a search platform later (#search-infra).
             leave room for a hook when a record is saved
 
 Conflict: appends to scalars/index.js. Two other features carry the same mark

--- a/kit/skills/hora-spec-backend/SKILL.md
+++ b/kit/skills/hora-spec-backend/SKILL.md
@@ -9,11 +9,11 @@ description: Stage 4 of /hora-spec. Declare the repositories and servers, then d
 
 Read `../hora/references/structure.md` and `../hora-spec/references/principles.md` first. `../hora-spec/references/stages.md` is the authority on this stage's exit condition, `../hora/references/spec-format.md` on the format of every table written here, and `../hora/references/asking.md` on how anything is put to a person.
 
-**This stage holds no design rule of its own.** How a table is shaped, how an SDL is named, where a job belongs and how a queue is tuned all live in `@openreachtech/hora-skills`. Invoke the skills the delegates table names and read them — never restate one of their rules here.
+**This stage holds no design rule of its own.** How a table is shaped, how an API schema is named, where a job belongs and how a queue is tuned all live in `@openreachtech/hora-skills`. Invoke the skills the delegates table names and read them — never restate one of their rules here.
 
 ## What this stage reads
 
-This is the stage that reads the backend properly: the migrations, the models, the SDL, the REST routes, the job definitions and the entry points, at depth.
+This is the stage that reads the backend properly: the migrations, the models, the API schemas, the REST routes, the job definitions and the entry points, at depth.
 
 **The whole existing data model and operation list goes out as checks, batched per area** — one for the tables, one for the operations, one for what runs outside the request. A person confirming the fourteenth table in a row has stopped reading (`../hora-spec/references/investigation.md`).
 
@@ -76,20 +76,20 @@ which processing does not run inside a request, and why not
 ```markdown
 | Repository | Origin | Role |
 |---|---|---|
-| `acme-backend` | renchan | the API and jobs (holds the DB) |
-| `acme-frontend-employee` | furo | the employee-facing screens |
-| `acme-frontend-admin` | furo | the admin screens |
+| `acme-backend` | `<a backend origin>` | the API and jobs (holds the DB) |
+| `acme-frontend-employee` | `<a frontend origin>` | the employee-facing screens |
+| `acme-frontend-admin` | `<a frontend origin>` | the admin screens |
 
 ### 2.1 Servers
 
 | Server | protocol | consumer |
 |---|---|---|
-| `employee-graphql` | GraphQL | `frontend-employee` |
-| `admin-graphql` | GraphQL | `frontend-admin` |
+| `employee-api` | (the default style) | `frontend-employee` |
+| `admin-api` | (the default style) | `frontend-admin` |
 | `worker` | — | an API server in the same repository (no contract needed) |
 ```
 
-- **Exactly one backend.** One DB system = one repository. Zero, or two, stops the run
+- **`Origin` comes from the stack handbook's catalog, and so does each origin's row count.** A count outside an origin's stated bounds — a second backend, say — stops the run
 - **Frontends are zero or more.** An API-only release declares none, and stage 5 is then not applicable
 - **Names read `<myproject>-<role>-<purpose>`**, from stage 1's project name
 - **The server table is the unit contracts are cut from**, so it is always written. `consumer` decides whether a contract exists at all
@@ -138,7 +138,7 @@ What belongs in the spec is the logical shape:
 
 ## 4. The operations
 
-**GraphQL is the default; REST needs a stated reason** (`../hora-spec/references/principles.md`).
+**The stack handbook's default API style is what a silent spec has chosen; another style needs a stated reason** (`../hora-spec/references/principles.md`).
 
 ```markdown
 | schema | input | result | kind |
@@ -159,7 +159,7 @@ AttendancesInput                      fields unknown
                                       → ask. blocking: yes
 ```
 
-Writing the SDL directly is the most reliable option, and a spec may do that instead of the table.
+Writing the schema definition directly, in the form the handbook names for the server's protocol, is the most reliable option, and a spec may do that instead of the table.
 
 **A REST server's row is written only when the server table declares a REST protocol**, and the renderer's own name is what gets implemented:
 
@@ -185,7 +185,7 @@ Writing the SDL directly is the most reliable option, and a spec may do that ins
 - **"Why not in the request path" is a required column.** A job with no reason is a job somebody will move back into the request later
 - **A job that must scale alone gets its own queue.** Stage 3 already named which thing it is
 - **Anything that leaves the process is worth naming here.** An external call in the request path makes somebody else's outage your error page
-- **Redis must be in stage 3's middleware table** if this section has any row at all. Go back and add it
+- **The queue's store must be in stage 3's middleware table** if this section has any row at all (the handbook's middleware rules). Go back and add it
 
 ## 6. Walk the use cases
 
@@ -212,7 +212,7 @@ Writing the SDL directly is the most reliable option, and a spec may do that ins
 | What is needed |
 |---|
 | the logical shape of a table — normalization, status, types, times, history, read scaling |
-| SDL, type and field naming, nullability, enums, pagination |
+| API schema, type and field naming, nullability, enums, pagination |
 | a REST renderer's route and version |
 | whether work belongs in the request, in a post-worker, or in a job |
 | a queue, a schedule, a retry, a concurrency limit |
@@ -246,6 +246,6 @@ The layout and server table declared; every table, operation and job written wit
 | `../hora/references/asking.md` | a check, a proposal or a question — and the question tool this stage defaults to |
 | `../hora-spec/SKILL.md` | the approval rule, the state file, the closing report |
 | `../hora-spec/references/stages.md` | this stage's exit condition |
-| `../hora-spec/references/principles.md` | roles or endpoints, GraphQL or REST, synchronous or a job, scale as a number |
+| `../hora-spec/references/principles.md` | roles or endpoints, the default API style or another, synchronous or a job, scale as a number |
 | `../hora/references/spec-format.md` | the format of every table here, and what stops the run |
 | `../hora-build/references/checkpoints.md` | checkpoints 3 to 7, which build what this stage designs |

--- a/kit/skills/hora-spec-frontend/SKILL.md
+++ b/kit/skills/hora-spec-frontend/SKILL.md
@@ -50,7 +50,7 @@ what each screen shows when there is nothing, when it is waiting, when it
 | a new operation | **stage 4.** A screen that needs one sends the run back there |
 | a table | stage 4 |
 | who may open a screen, as a permission | **stage 6.** This stage writes which actor a screen is for; stage 6 writes what happens to everybody else |
-| a component, a token, a CSS class, a Vue file | **`/hora-build`**, at checkpoints 12 to 16 |
+| a component, a token, a CSS class, a component file | **`/hora-build`**, at checkpoints 12 to 16 |
 | anything about how a screen is built | the package's own frontend skills |
 
 **A screen list is not a design.** What makes this stage worth a gate is the mapping — which use case passes through which screens, and which operations each screen calls. Without it, checkpoint 11 has nothing to verify against.
@@ -128,7 +128,7 @@ If nothing equipped covers a row, say so by the work it names, carry on, and rec
 ## 13. Screens
 <!-- id: screens -->
 <!-- target: frontend-employee -->
-<!-- depends: graphql -->
+<!-- depends: api -->
 
 ### 13.1 The month's attendance
 

--- a/kit/skills/hora-spec-nonfunctional/SKILL.md
+++ b/kit/skills/hora-spec-nonfunctional/SKILL.md
@@ -114,13 +114,14 @@ which middleware the project needs, and at which server version
 
 | Middleware | Version | profile | Purpose |
 |---|---|---|---|
-| MariaDB | 10.5.12 | (default) | the primary data store |
-| Redis | 7.4 | (default) | BullMQ |
-| MinIO | latest | `minio` | S3-compatible object storage |
+| <the data store> | <the server's version> | (default) | the primary data store |
+| <the queue's store> | <the server's version> | (default) | the queue |
+| <object storage> | latest | `<its profile>` | S3-compatible object storage |
 ```
 
+- **Start from the stack handbook's default middleware table** (`docs/stack/middleware.md`) and declare what this project actually uses
 - **Write the server's version, not a driver's.** An npm dependency does not indicate the server version, and without it `/hora` has to guess
-- **Redis cannot be left out of a project with any background job** (BullMQ needs it). Where stage 3 already knows a job is coming, declare it now
+- **The queue's store cannot be left out of a project with any background job** (the handbook's middleware rules). Where stage 3 already knows a job is coming, declare it now
 - **`profile` and `COMPOSE_PROFILES` are what `/hora-setup` derives from this table** — a middleware the table omits is one that never comes up, and acceptance stops rather than reviewing something that is not really running
 
 ---

--- a/kit/skills/hora-spec-security/SKILL.md
+++ b/kit/skills/hora-spec-security/SKILL.md
@@ -135,15 +135,16 @@ And the rest as non-functional requirements, since they constrain every feature:
 ```markdown
 | Item | Requirement |
 |---|---|
-| Authentication | staff and managers share one login on `employee-graphql`, switched on
-                   role. Administrators authenticate separately on `admin-graphql` |
+| Authentication | staff and managers share one login on `employee-api`, switched on
+                   role. Administrators authenticate separately on `admin-api` |
 | Authorization | every operation states its caller in its own table. An operation
                   reached by anybody else is refused with `not-allowed`, never
                   with a silent empty result |
 | Personal data | `staffs.email`, `staffs.name`, every `attendances` row. Never
                   written to a log, never included in an error message |
 | Rate limiting | sign-in only, at 1.0.0 |
-| Exposure | only the two GraphQL servers are reachable. MariaDB and Redis are not |
+| Exposure | only the two API servers are reachable. The data store and the queue's
+             store are not |
 ```
 
 ### The acceptance criteria this stage adds

--- a/kit/skills/hora-spec/references/investigation.md
+++ b/kit/skills/hora-spec/references/investigation.md
@@ -185,7 +185,7 @@ What was read, where it was read from, and when. **A cache and an audit trail â€
 
 | Row | Directory | Read at | What it holds |
 |---|---|---|---|
-| backend | `legacy-api` | `a1b2c3d` | 14 GraphQL operations, 9 tables, 2 jobs, 118 tests |
+| backend | `legacy-api` | `a1b2c3d` | 14 API operations, 9 tables, 2 jobs, 118 tests |
 | frontend-admin | `admin-console` | `e4f5g6h` | 11 pages, 6 of them behind a role check |
 
 ## Documents

--- a/kit/skills/hora-spec/references/principles.md
+++ b/kit/skills/hora-spec/references/principles.md
@@ -58,18 +58,13 @@ Hora Kit holds no procedure and no pass/fail criterion that `@openreachtech/hora
 
 ---
 
-## 4. GraphQL is the default. REST is a choice with a reason
+## 4. The boilerplates' own API style is the default. Another is a choice with a reason
 
-**On renchan and Furo, GraphQL is what the boilerplates are built around**, so a spec that says nothing has said GraphQL.
+**The stack handbook names the API style the boilerplates are built around** (`docs/stack/middleware.md`), so a spec that says nothing has said that.
 
-**REST is available, and choosing it needs a stated reason.** Reasons that count:
+**Another style is available, and choosing it needs a stated reason.** The reasons that count are the handbook's too — a consumer that already exists and already speaks it, a third party that cannot speak the default, a transfer the default is a poor fit for, a public surface whose fixed URL shape is part of the contract.
 
-- a consumer that already exists and already speaks REST
-- a third party that cannot speak GraphQL — a webhook, a callback, a device
-- a transfer GraphQL is a poor fit for: a file download, a redirect, a raw payload
-- a public surface where a fixed URL shape is part of the contract
-
-**Both may exist in one backend, per server, and the server table is where that is declared.** What belongs to the spec is which servers exist, who consumes each, and why.
+**Several styles may exist in one backend, per server, and the server table is where that is declared.** What belongs to the spec is which servers exist, who consumes each, and why.
 
 ---
 

--- a/kit/skills/hora-spec/references/stages.md
+++ b/kit/skills/hora-spec/references/stages.md
@@ -4,7 +4,7 @@
 
 **Stage 0 is numbered 0 because it does not renumber anything.** It gathers what already exists so that the seven stages have something to correct instead of something to dictate. On a new project it passes in a sentence.
 
-**This file holds the order and the exit conditions. It holds no design rule.** How a table is shaped, how an SDL is named, where a background job belongs and what a screen must account for all live in `@openreachtech/hora-skills` (`../../hora/references/structure.md`, "The division of labor").
+**This file holds the order and the exit conditions. It holds no design rule.** How a table is shaped, how an API schema is named, where a background job belongs and what a screen must account for all live in `@openreachtech/hora-skills` (`../../hora/references/structure.md`, "The division of labor").
 
 **No stage below names a package skill, and none ever may.** Each **Delegate to** row says what has to be covered, and the main session matches that against the equipped skills' own descriptions when it enters the stage (`../../hora/references/structure.md`, "No hora file ever names one of those skills").
 
@@ -165,12 +165,12 @@ A stage is **a gate with one exit condition**, exactly like a checkpoint. Passin
 | | |
 |---|---|
 | **Skill** | `/hora-spec-backend` |
-| **Delegate to** | the skills covering each of: the logical shape of a table (what to normalize, how to hold a status, a time, a history); SDL, type and field naming, nullability, enums, pagination; a REST renderer's route and version; whether work belongs in the request path, in a post-worker or in a background job; a queue, a schedule, a retry; a side effect after the response; what an endpoint is and what its auth filter does |
+| **Delegate to** | the skills covering each of: the logical shape of a table (what to normalize, how to hold a status, a time, a history); API schema, type and field naming, nullability, enums, pagination; a REST renderer's route and version; whether work belongs in the request path, in a post-worker or in a background job; a queue, a schedule, a retry; a side effect after the response; what an endpoint is and what its auth filter does |
 | **Exit condition** | the repository layout and the server table are declared; every use case from stage 1 can be walked against the data model and the operation list, step by step, without a gap; every operation states its kind; and every write states whether it completes inside the request or runs as a job |
 | **Not applicable when** | never. A version with no backend row still has to declare that |
 | **Carried over when** | **this version adds no table, no operation and no job.** Otherwise it runs **on the new ones alone**, reading the existing model as context. **A new repository row or a new server is never a carry-over** |
-| **Writes** | `Repository layout` and its server table, `Data model`, `GraphQL`, `RESTful API`, `Background jobs`, and `Key file map` where anything about placement is known — with the `<!-- acceptance -->` blocks those sections carry |
-| **Reads** | **deeply** — migrations, models, SDL, REST routes, job definitions and the entry points. The whole existing data model and operation list can go out as one check per area |
+| **Writes** | `Repository layout` and its server table, `Data model`, the API sections (one per protocol the server table declares), `Background jobs`, and `Key file map` where anything about placement is known — with the `<!-- acceptance -->` blocks those sections carry |
+| **Reads** | **deeply** — migrations, models, API schemas, REST routes, job definitions and the entry points. The whole existing data model and operation list can go out as one check per area |
 
 **Walking the use cases is the exit condition, not a review step.** A data model that is internally tidy and cannot represent one stated use case passes every other check in this document. Stage 7 walks them again; this stage walks them first, while changing a table still costs a sentence.
 

--- a/kit/skills/hora/references/spec-format.md
+++ b/kit/skills/hora/references/spec-format.md
@@ -563,16 +563,16 @@ The skeleton's sections 9 onward are **examples of feature sections, not a fixed
 ```markdown
 | Repository | Origin | Role |
 |---|---|---|
-| `<myproject>-backend` | renchan | the API and jobs (holds the DB) |
-| `<myproject>-frontend-employee` | furo | the employee-facing screens |
-| `<myproject>-frontend-admin` | furo | the admin screens |
+| `<myproject>-backend` | `<a backend origin>` | the API and jobs (holds the DB) |
+| `<myproject>-frontend-employee` | `<a frontend origin>` | the employee-facing screens |
+| `<myproject>-frontend-admin` | `<a frontend origin>` | the admin screens |
 
 ### 2.1 Servers
 
 | Server | protocol | consumer |
 |---|---|---|
-| `employee-graphql` | GraphQL | `frontend-employee` |
-| `admin-graphql` | GraphQL | `frontend-admin` |
+| `employee-api` | (the default style) | `frontend-employee` |
+| `admin-api` | (the default style) | `frontend-admin` |
 | `public-rest` | REST | the phone app |
 | `worker` | — | an API server in the same repository (no contract needed) |
 ```
@@ -580,12 +580,13 @@ The skeleton's sections 9 onward are **examples of feature sections, not a fixed
 **`/hora-setup` reads this table to decide which repositories to clone. Without it, it stops.**
 
 - **This section belongs in the entry point.** The layout applies to the whole version
-- **The backend is exactly one.** One DB system = one repository, so `/hora` stops with a question at zero, or at two or more
-- **Frontends are zero or more, freely.** `furo` cannot hold more than one Nuxt app per repository, so repositories split along groups of screens
-- **One backend holds several servers side by side.** **The server table is the unit contracts are derived from, so it must always be written**, and its `consumer` column says which frontend looks at which contract
+- **`Origin` is one of the values the stack handbook's catalog lists** (`docs/stack/README.md` at the project root). A value the catalog does not list is not an origin
+- **How many rows of each origin may be declared is also the catalog's.** A count outside an origin's stated bounds — a second backend, say — stops `/hora` with a question: it is an architectural decision, not a row to add
+- **Frontends are zero or more, freely.** Where the catalog says one repository cannot hold more than one app, repositories split along groups of screens
+- **One backend holds several servers side by side.** **The server table is the unit contracts are derived from, so it must always be written**, and its `consumer` column says which frontend looks at which contract. A `protocol` left as the default is the handbook's default API style
 - **Adding a row in a later version** makes `/hora-setup` create that repository when the version is planned
 - **Names read `<myproject>-<role>-<purpose>`** — `<myproject>-frontend-admin`, not `<myproject>-admin-frontend`
-- **`Origin` is either `renchan` (backend) or `furo` (frontend).** `<myproject>-app` is not written here — it always exists
+- **`<myproject>-app` is not written here** — it always exists
 - **`target`'s value is this table's repository name with `<myproject>-` removed**
 
 #### `Directory` — for a repository that already exists under another name
@@ -595,7 +596,7 @@ The skeleton's sections 9 onward are **examples of feature sections, not a fixed
 ```markdown
 | Repository | Origin | Role | Directory |
 |---|---|---|---|
-| `acme-backend` | renchan | the API and jobs (holds the DB) | `legacy-api` |
+| `acme-backend` | `<a backend origin>` | the API and jobs (holds the DB) | `legacy-api` |
 ```
 
 | The column is | What `/hora-setup` does |
@@ -700,14 +701,14 @@ Produces no feature of its own, **but becomes a design constraint on every one o
 ```markdown
 | Middleware | Version | profile | Purpose |
 |---|---|---|---|
-| MariaDB | 10.5.12 | (default) | the primary data store |
-| Redis | 7.4 | (default) | BullMQ |
-| MinIO | latest | `minio` | S3-compatible object storage |
+| <the data store> | <the server's version> | (default) | the primary data store |
+| <the queue's store> | <the server's version> | (default) | the queue |
+| <object storage> | latest | `<its profile>` | S3-compatible object storage |
 ```
 
-What `/hora-setup` uses to decide `docker-compose.development.yml`'s profiles and `.env.development`'s `COMPOSE_PROFILES`.
+**Start from the stack handbook's default middleware table** (`docs/stack/middleware.md`) and declare what this project actually uses. This is what `/hora-setup` uses to decide which optional local services get turned on.
 
-**Write the server's version.** An npm dependency does not indicate the server's version. **Redis cannot be dropped in a project with any Job (BullMQ).**
+**Write the server's version.** An npm dependency does not indicate the server's version. **A middleware the handbook marks as required by another declaration — the queue's store, in a project with any background job — cannot be dropped.**
 
 ### 9 onward — the feature sections
 
@@ -715,7 +716,7 @@ Each one carries its annotations, then its content, then its `<!-- usecases -->`
 
 **A data model section is the one that carries acceptance criteria without use cases of its own.** A table has no user-facing use case; the features built on it do.
 
-**An API table must state the kind of every operation**, and the kind is never inferred (`structure.md`, invariant 2). `/hora-build` branches on the value at three separate checkpoints. Leave it out and `/hora-plan` stops with `undefined-api-kind` (`blocking: yes`).
+**An API table must state the kind of every operation**, and the kind is never inferred (`structure.md`, invariant 2). **The set of kinds a spec may write, and what each one produces, is the stack handbook's** (`docs/stack/artifacts.md`). `/hora-build` branches on the value at three separate checkpoints. Leave it out and `/hora-plan` stops with `undefined-api-kind` (`blocking: yes`).
 
 **It must also state who may call every operation**, in the same table. An operation whose caller was never stated gets implemented with whatever filter its neighbours had. Leave it out and `/hora-plan` stops with `missing-authorization` (`blocking: yes`).
 
@@ -738,7 +739,7 @@ RpaFlowsInput              fields unknown
                            → stops with blocking: yes
 ```
 
-Writing the SDL directly is the most reliable option.
+Writing the schema definition directly, in the form the handbook names for the server's protocol, is the most reliable option.
 
 **The RESTful API section is written only when the repository layout declares a REST server**, and a project with none leaves it out. The same rules apply, and **the renderer's own name is what gets implemented and what the frontend's client is built against.**
 
@@ -748,7 +749,7 @@ Writing the SDL directly is the most reliable option.
 | `GET` | `/v1/rpa-flows` | `GetRpaFlowsRenderer` | `?page=&limit=` | `RpaFlowsResponse` | the phone app, with a device token |
 ```
 
-**A background-jobs section states what does not run inside a request, and why not.** It is written only where something does, and a project with any row must also declare Redis in the manual verification table.
+**A background-jobs section states what does not run inside a request, and why not.** It is written only where something does, and a project with any row must also declare the queue's store in the manual verification table (the handbook's middleware rules).
 
 ```markdown
 | Job | Trigger | Queue | Payload | Why not in the request path |


### PR DESCRIPTION
## What this does

Second of four phases (stacks on #100 — its commits show here until that merges; merge in order).

Removes every stack concrete from the spec-side skills, delegating each to the stack handbook (openreachtech/hora-boilerplate#70):

- **`spec-format.md`** — the `Origin` column's valid values and each origin's row count now come from the handbook's catalog (previously `renchan` / `furo` were enumerated, with "exactly one backend" hardcoded); the manual-verification example is a shape with placeholders, starting from the handbook's default middleware table; the "Redis with any Job (BullMQ)" rule became "the queue's store, per the handbook's middleware rules"; API-kind sets and schema forms point at `docs/stack/artifacts.md`. Layout examples use `<a backend origin>` placeholders and `employee-api` server names.
- **`principles.md` §4** — "GraphQL is the default" became "the boilerplates' own API style is the default", named by the handbook.
- **`stages.md` / `investigation.md` / the four stage skills** (backend, frontend, nonfunctional, security) — SDL → API schema, middleware tables delegated, examples de-stacked.
- **`hora-plan/SKILL.md`** — contract files are "one per server, in the form the handbook names for its protocol" instead of literal `employee-graphql.graphql`; question-catalog and example wording de-stacked.

Section headings inside an actual `spec.md` (e.g. the skeleton's "10. GraphQL") are the **skeleton's own**, which ships with the boilerplate — core already recognizes required sections by role, not by heading text, so nothing here renames anything in existing specs.

## Notes

`npm test` green (861). Remaining stack tokens in `kit/` are now confined to `hora-build/references/checkpoints.md` and the agents — phase 3's targets, along with the `bank-id` move to hora-skills.

🤖 Generated with [Claude Code](https://claude.com/claude-code)