### PR TITLE
🐛 Read the digest source from the package a skill came from

### DIFF
--- a/kit/agents/hora-digester.md
+++ b/kit/agents/hora-digester.md
@@ -10,7 +10,7 @@ Read **one equipped skill** and write its digest. That one file is your whole ou
 
 ```
 the skill        its name, and its directory under .claude/skills/<skill-name>/
-the version      the @openreachtech/hora-skills version now installed
+the source       the skills package it came from, and that package's installed version
 the destination  .hora/digests/<skill-name>.md
 ```
 
@@ -22,7 +22,7 @@ the destination  .hora/digests/<skill-name>.md
 
 **An implementer keeps the conventions it was handed resident for every turn it takes, so a skill of several thousand lines is paid for hundreds of times over.** The digest is the same conventions at a size that survives that multiplication.
 
-**What makes this safe is that the digest is not the last word.** It names its source, `/hora-build` uses it only while it names the installed version, and the implementer opens the skill itself the moment a question stays open. A rule you compress too far therefore costs one read. **A rule you drop silently costs a convention**, and that is the one failure worth writing carefully against.
+**What makes this safe is that the digest is not the last word.** It names its source, `/hora-build` uses it only while it names the installed package and version, and the implementer opens the skill itself the moment a question stays open. A rule you compress too far therefore costs one read. **A rule you drop silently costs a convention**, and that is the one failure worth writing carefully against.
 
 ---
 
@@ -57,7 +57,7 @@ the destination  .hora/digests/<skill-name>.md
 
 ```markdown
 # <skill-name>
-<!-- hora-skills <version> -->
+<!-- <package> <version> -->
 <!-- source: .claude/skills/<skill-name>/ -->
 
 **Read the source above whenever this leaves a question open.**

--- a/kit/skills/hora-build/SKILL.md
+++ b/kit/skills/hora-build/SKILL.md
@@ -126,13 +126,13 @@ Report the decision in one line before starting work — "building #attendance, 
 3. Pick every one whose description covers that work, on the surface this
    checkpoint's repository requires (hb- backend, hf- frontend, hc- either)
 4. Take a digest of each one (below)
-5. Write the names, and the version those digests were derived from, into
-   the feature file against this checkpoint
+5. Write the names, and the package and version those digests were derived
+   from, into the feature file against this checkpoint
 6. Hand the names and the digest paths to the agent, in its assignment
 ```
 
 ```markdown
-- [x] 15. UI  <!-- skills: <every name you matched, comma-separated>; digests: <package version> -->
+- [x] 15. UI  <!-- skills: <every name you matched, comma-separated>; digests: <the package and version each came from> -->
 ```
 
 **The example above carries no real name on purpose.** This is a hora file, so the rule it states applies to it too.
@@ -150,10 +150,11 @@ Report the decision in one line before starting work — "building #attendance, 
 **A matched skill can run to thousands of lines, and it stays resident in the agent's context for every turn.** A checkpoint's cost is close to that resident size multiplied by its turn count. `.hora/digests/<skill-name>.md` is the short form.
 
 ```
-1. Read the installed version from
-   node_modules/@openreachtech/hora-skills/package.json
+1. For each matched skill, find the record under .hora/ that names it. There is
+   one record per equipped skills package, the file is named after the package,
+   and its version: is the version of that package now installed
 2. For each skill matched above, use .hora/digests/<skill-name>.md while its
-   header names that version
+   header names that package and that version
 3. For the rest, start hora-digester — one agent per skill, all in one
    message — and use the files they write
 4. Hand those paths to the agent, alongside the skill names
@@ -161,7 +162,7 @@ Report the decision in one line before starting work — "building #attendance, 
 
 **Nothing matched, nothing digested.** When the match above came back empty, this step is skipped whole — there is no version to read and no digest to take — and the checkpoint runs on what it stated itself.
 
-**The version in the header is what keeps a digest honest.** It holds only while it names the version it came from, so a package update leaves every digest to be rewritten before it is read again.
+**The package and version in the header are what keep a digest honest.** A digest holds only while it names what it came from, so updating one package leaves that package's digests to be rewritten before they are read again — and leaves the others alone.
 
 **A digest names the skill it came from, and the agent reads that skill whenever a question stays open** (`../../agents/hora-digester.md`), so a convention a digest states too thinly costs one read.
 

--- a/kit/skills/hora/references/structure.md
+++ b/kit/skills/hora/references/structure.md
@@ -318,7 +318,7 @@ Q4  missing-authorization  blocking: yes
                                 refuses to pass while a row is unrouted
   tree/<repository>.md          what /hora-setup read in the real tree, and the tag it read it at
   digests/<skill-name>.md       one equipped skill's conventions in short form, and the
-                                hora-skills version they were derived from.
+                                package and version they were derived from.
                                 hora-digester writes it. A cache; the skill stays the authority
   tasks/<version>/
     _plan.md                    the feature order, and the acceptance tasks. /hora-plan writes it


### PR DESCRIPTION
# Why

* Close #112

# How

* **The path step 3 read no longer exists.** `hora-skills` was split into `hora-skills-ort-core`, `-ort-renchan` and `-ort-furo`, so `node_modules/@openreachtech/hora-skills/package.json` resolves to nothing and the step had no version to read. It now reads the package each matched skill came from, named by its prefix — `hoc-`, `hor-`, `hof-`
* A digest header carries that package beside the version, so it stays honest with three packages the way a bare version did with one: updating one package leaves that package's digests to be rewritten and the others alone
* `hora-digester` is handed the source rather than a lone version, and the `.hora/` tree in `structure.md` says the same

The prose that describes the boundary in the other hora skills follows in its own pull request.
