### PR TITLE
🏷️ Update the skill prefixes the kit matches on

### DIFF
--- a/kit/skills/hora-build/SKILL.md
+++ b/kit/skills/hora-build/SKILL.md
@@ -124,7 +124,7 @@ Report the decision in one line before starting work — "building #attendance, 
 1. Take the work the checkpoint's "Delegate to" row states
 2. Read the descriptions of the skills equipped under .claude/skills/
 3. Pick every one whose description covers that work, on the surface this
-   checkpoint's repository requires (hb- backend, hf- frontend, hc- either)
+   checkpoint's repository requires (hor- backend, hof- frontend, hoc- either)
 4. Take a digest of each one (below)
 5. Write the names, and the package and version those digests were derived
    from, into the feature file against this checkpoint

--- a/kit/skills/hora/SKILL.md
+++ b/kit/skills/hora/SKILL.md
@@ -47,7 +47,7 @@ Read `references/structure.md` before anything else — the repository layout, w
 
 ```
 Is there at least one skill under .claude/skills/ whose name carries an
-hb- / hf- / hc- prefix?
+hoc- / hor- / hof- prefix?
                              if not → stop. Report that the implementation
                                       skills are not equipped, and ask for
                                       them to be equipped before rerunning

--- a/kit/skills/hora/references/structure.md
+++ b/kit/skills/hora/references/structure.md
@@ -69,9 +69,9 @@
 
 | Prefix | Applies to |
 |---|---|
-| `hb-` (hora-backend) | the backend repository |
-| `hf-` (hora-frontend) | a frontend repository |
-| `hc-` (hora-core) | either |
+| `hor-` | the backend repository |
+| `hof-` | a frontend repository |
+| `hoc-` | either |
 
 If nothing equipped covers the work, **say so and continue without it.** Guessing at a substitute is worse than proceeding and reporting the gap.
 


### PR DESCRIPTION
# Why

* Close #114

# How

* The equipped skills carry `hoc-` / `hor-` / `hof-` since the skills package was split into one package per domain, so the three places the kit reads a prefix read the new ones. `/hora` stops on nothing equipped, and `hora-build` picks by surface, and both were matching prefixes that no longer arrive
* The prefix table drops the parenthetical gloss it carried — `(hora-backend)` / `(hora-frontend)` / `(hora-core)`. The column beside it already says which surface each serves, and `hora-core` in particular named a different thing entirely: the command that installs `@openreachtech/hora`, which distributes no such skill
