### PR TITLE
📄 Name the three skills packages where the kit states the division of labor

### DIFF
--- a/kit/agents/hora-implementer.md
+++ b/kit/agents/hora-implementer.md
@@ -26,7 +26,7 @@ the scope         the repository to work in, and this feature's row-id prefix
 
 ## Follow the skills you were handed
 
-**You were handed the names of skills from `@openreachtech/hora-skills`, and those skills hold how the work is actually done.** `/hora-build` holds the order and the exit condition; it deliberately holds no procedure.
+**You were handed the names of skills from the `@openreachtech/hora-skills-ort-*` packages, and those skills hold how the work is actually done.** `/hora-build` holds the order and the exit condition; it deliberately holds no procedure.
 
 **Each name arrives with a digest — `.hora/digests/<skill-name>.md` — and the digest is where to start.** **Invoke the skill itself through the `Skill` tool the moment a question stays open**: when the digest points you there, when it covers your case thinly, or when what you are about to write is not obviously the thing it describes.
 

--- a/kit/skills/hora-accept/SKILL.md
+++ b/kit/skills/hora-accept/SKILL.md
@@ -13,7 +13,7 @@ Read `../hora/references/structure.md` first. **This skill is strictly read-only
 
 ## What this skill does not contain
 
-**The content of an acceptance review, and the criteria it passes or fails on, are not in this file and must never be written into it.** They live in `@openreachtech/hora-skills`, and this skill delegates the work.
+**The content of an acceptance review, and the criteria it passes or fails on, are not in this file and must never be written into it.** They live in the `@openreachtech/hora-skills-ort-*` packages, and this skill delegates the work.
 
 | What is needed | Whose it is |
 |---|---|

--- a/kit/skills/hora-build/references/checkpoints.md
+++ b/kit/skills/hora-build/references/checkpoints.md
@@ -2,7 +2,7 @@
 
 **The authority on the checkpoint list.** `/hora-plan` copies the list from here into each feature file; `/hora-build` runs a feature through it.
 
-**This file holds the order and the exit conditions. It holds no procedure.** How to write a migration, a resolver, a component or a test lives in `@openreachtech/hora-skills`, and each checkpoint states the *work* that skill covers (`../../hora/references/structure.md`, "The division of labor").
+**This file holds the order and the exit conditions. It holds no procedure.** How to write a migration, a resolver, a component or a test lives in the `@openreachtech/hora-skills-ort-*` packages, and each checkpoint states the *work* that skill covers (`../../hora/references/structure.md`, "The division of labor").
 
 **No checkpoint below names a package skill, and none ever may.** Each checkpoint's **Delegate to** row says what has to be covered, and the main session matches that against the equipped skills' own descriptions at run time (`../../hora/references/structure.md`, "No hora file ever names one of those skills"). **Skills Hora Kit itself ships — `/hora-accept` — are named here freely.**
 

--- a/kit/skills/hora-spec-backend/SKILL.md
+++ b/kit/skills/hora-spec-backend/SKILL.md
@@ -9,7 +9,7 @@ description: Stage 4 of /hora-spec. Declare the repositories and servers, then d
 
 Read `../hora/references/structure.md` and `../hora-spec/references/principles.md` first. `../hora-spec/references/stages.md` is the authority on this stage's exit condition, `../hora/references/spec-format.md` on the format of every table written here, and `../hora/references/asking.md` on how anything is put to a person.
 
-**This stage holds no design rule of its own.** How a table is shaped, how an API schema is named, where a job belongs and how a queue is tuned all live in `@openreachtech/hora-skills`. Invoke the skills the delegates table names and read them — never restate one of their rules here.
+**This stage holds no design rule of its own.** How a table is shaped, how an API schema is named, where a job belongs and how a queue is tuned all live in the `@openreachtech/hora-skills-ort-*` packages. Invoke the skills the delegates table names and read them — never restate one of their rules here.
 
 ## What this stage reads
 

--- a/kit/skills/hora-spec-nonfunctional/SKILL.md
+++ b/kit/skills/hora-spec-nonfunctional/SKILL.md
@@ -13,7 +13,7 @@ Read `../hora/references/structure.md` and `../hora-spec/references/principles.m
 
 **Offer numbers as options, never as a blank.** "How many users?" produces a shrug; `200 / 2,000 / 20,000`, with today's row count named alongside, produces an answer in one exchange (`../hora/references/asking.md`).
 
-**Nothing in `@openreachtech/hora-skills` owns this stage, and nothing could.** No skill states what a project's user count or availability target should be. What is written below is which questions to ask; every answer is the requester's.
+**Nothing in the `@openreachtech/hora-skills-ort-*` packages owns this stage, and nothing could.** No skill states what a project's user count or availability target should be. What is written below is which questions to ask; every answer is the requester's.
 
 ---
 

--- a/kit/skills/hora-spec/references/principles.md
+++ b/kit/skills/hora-spec/references/principles.md
@@ -6,7 +6,7 @@
 
 ## The boundary this file sits on
 
-Hora Kit holds no procedure and no pass/fail criterion that `@openreachtech/hora-skills` already holds (`../../hora/references/structure.md`, "The division of labor"). The line runs like this:
+Hora Kit holds no procedure and no pass/fail criterion that the `@openreachtech/hora-skills-ort-*` packages already hold (`../../hora/references/structure.md`, "The division of labor"). The line runs like this:
 
 | | Owns | Example |
 |---|---|---|

--- a/kit/skills/hora-spec/references/stages.md
+++ b/kit/skills/hora-spec/references/stages.md
@@ -4,7 +4,7 @@
 
 **Stage 0 is numbered 0 because it does not renumber anything.** It gathers what already exists so that the seven stages have something to correct instead of something to dictate. On a new project it passes in a sentence.
 
-**This file holds the order and the exit conditions. It holds no design rule.** How a table is shaped, how an API schema is named, where a background job belongs and what a screen must account for all live in `@openreachtech/hora-skills` (`../../hora/references/structure.md`, "The division of labor").
+**This file holds the order and the exit conditions. It holds no design rule.** How a table is shaped, how an API schema is named, where a background job belongs and what a screen must account for all live in the `@openreachtech/hora-skills-ort-*` packages (`../../hora/references/structure.md`, "The division of labor").
 
 **No stage below names a package skill, and none ever may.** Each **Delegate to** row says what has to be covered, and the main session matches that against the equipped skills' own descriptions when it enters the stage (`../../hora/references/structure.md`, "No hora file ever names one of those skills").
 

--- a/kit/skills/hora/SKILL.md
+++ b/kit/skills/hora/SKILL.md
@@ -159,7 +159,7 @@ Report the decision in one line before starting work — for example, "continuin
 
 ## Where the procedures live
 
-**`/hora` holds the order. It holds no procedure and no pass/fail criterion.** How to write a resolver, a migration, a component or a test — and what an acceptance review looks at — all live in `@openreachtech/hora-skills`, equipped under this repository's own `.claude/skills/`.
+**`/hora` holds the order. It holds no procedure and no pass/fail criterion.** How to write a resolver, a migration, a component or a test — and what an acceptance review looks at — all live in the `@openreachtech/hora-skills-ort-*` packages, equipped under this repository's own `.claude/skills/`.
 
 **Never write one of those procedures into a hora skill** (`references/structure.md`, "The division of labor").
 

--- a/kit/skills/hora/references/structure.md
+++ b/kit/skills/hora/references/structure.md
@@ -15,12 +15,12 @@
 | which repositories exist, and what fills them | Hora Kit | `/hora-setup` |
 | which version is being built, and which features it holds | Hora Kit | `/hora-plan` |
 | **the order of the checkpoints, and each one's exit condition** | Hora Kit | `/hora-build` |
-| **how to write, shape and review the work itself** — an operation, a table, a job, a screen, a test | **`@openreachtech/hora-skills`** | that package's own skills |
-| **what an acceptance review looks at, and what it fails on** | **`@openreachtech/hora-skills`** | whichever of its skills covers that work |
+| **how to write, shape and review the work itself** — an operation, a table, a job, a screen, a test | **the `@openreachtech/hora-skills-ort-*` packages** | those packages' own skills |
+| **what an acceptance review looks at, and what it fails on** | **the `@openreachtech/hora-skills-ort-*` packages** | whichever of their skills covers that work |
 | **which boilerplate fills a declared row, what gets filled in, and what to read once it arrived** | **the stack handbook** | `docs/stack/` at the project root, shipped by the boilerplate (`../../hora-setup/references/handbook.md`) |
 | **the stack's structural facts** — its origins and their bounds, its middleware and defaults, its default API style, what an API kind produces | **the stack handbook** | whichever of its files covers that answer |
 
-**Never write a procedure, a convention or a pass/fail criterion into a hora skill when a skill in `hora-skills` already holds it.** State the work and delegate it. A copy disagrees with the original the first time the package is updated, and nothing announces that it has.
+**Never write a procedure, a convention or a pass/fail criterion into a hora skill when a skill in the `hora-skills-ort-*` packages already holds it.** State the work and delegate it. A copy disagrees with the original the first time the package is updated, and nothing announces that it has.
 
 **The same holds for the stack.** Never write a stack's answer — a boilerplate's name, a framework, a middleware, a default — into a hora file. The stack handbook is where those answers live, found at its fixed place and read at run time; a hora file states the kind of answer it needs, and a missing answer is a stop-and-ask, never a guess.
 


### PR DESCRIPTION
# Why

* Close #116

# How

* Eleven passages named `@openreachtech/hora-skills` as the one place every procedure and pass/fail criterion lives. They name the `@openreachtech/hora-skills-ort-*` packages now, and the sentences around them agree in number
* **Named by the glob, not one by one.** `tests/__tests__/kit/stack-free.js` forbids a stack name anywhere under `kit/`, and two of the three package names carry one — so the kit says what it always said: the kind of place the answer comes from, never which stack it is for
* No behavior in this pull request: the prefixes the kit matches on and the digest source were the two that mattered, and both are already in
