### PR TITLE
📄 Update the documents for the three skills packages

### DIFF
--- a/.claude/skills/flatten/SKILL.md
+++ b/.claude/skills/flatten/SKILL.md
@@ -13,7 +13,7 @@ description: "Repository-specific build convention: everything under kit/ is cop
 
 **Nothing is flattened here.** `kit/` is already the shape consuming repositories install, and this build copies it through unchanged.
 
-The name is borrowed from `@openreachtech/hora-skills`, whose build genuinely does flatten — its `kit/skills/` is grouped into `_core/`, `backend/` and `frontend/` domain directories, and the build drops that level to produce `dist/skills/`. Both repositories distribute a skill set, both build `kit/` into `dist/` under `prepack`, and both put that build behind a skill of this name. **One name across the two repositories means one thing to learn**: whichever you open, `flatten` is where the publish payload is produced, and the answer to "what does this repository do to its skills before shipping them?" is on this page.
+The name is borrowed from the `@openreachtech/hora-skills-ort-*` packages, whose builds genuinely do flatten — each one’s `kit/skills/` holds the single domain directory of that package, and the build drops that level to produce `dist/skills/`. Those repositories distribute a skill set too, both build `kit/` into `dist/` under `prepack`, and both put that build behind a skill of this name. **One name across the two repositories means one thing to learn**: whichever you open, `flatten` is where the publish payload is produced, and the answer to "what does this repository do to its skills before shipping them?" is on this page.
 
 Here the answer is "nothing at all". That is a fact about today's `kit/`, not a promise — the seam exists so a transformation can be added on one side without the other side's reader having to relearn where to look.
 
@@ -58,9 +58,9 @@ kit/agents/hora-verifier.md   name: hora-verifier   →   dist/agents/hora-verif
 
 ### No prefix rule
 
-Unlike `hora-skills`, this repository enforces no prefix. Its skills are named `hora-*` by convention because they are Hora Kit's own commands, but that is a convention, not a checked rule.
+Unlike those packages, this repository enforces no prefix. Its skills are named `hora-*` by convention because they are Hora Kit's own commands, but that is a convention, not a checked rule.
 
-`bank-id` is the one name outside it, deliberately: it is to be moved into `hora-skills` as `hb-bank-id` later, and renaming it here first would only be undone by that move.
+`bank-id` is the one name outside it, deliberately: it is to be moved into `hora-skills-ort-renchan` as `hor-bank-id` later, and renaming it here first would only be undone by that move.
 
 ## The build
 

--- a/docs/architecture.ja.md
+++ b/docs/architecture.ja.md
@@ -33,14 +33,14 @@ Hora Kit が仕様書をアプリケーションに変えるまで。何がど�
 
 ## 4つの層
 
-![4つの層：/hora、5つの skill、ステージ skill と2つのエージェント、そして hora-skills](./images/layers.ja.svg)
+![4つの層：/hora、5つの skill、ステージ skill と2つのエージェント、そして3つのスキルパッケージ](./images/layers.ja.svg)
 
 | 層 | 決めること | 決してしないこと | 配布元 |
 |---|---|---|---|
 | `/hora` | 次にどの段階が来るか。すべてのブランチ・コミット・マージ | 作業の中身に関する一切 | `@openreachtech/hora` |
 | 5つの skill | 作業の順序と、各関所の終了条件 | その書き方 | `@openreachtech/hora` |
 | ステージ skill と2つの agent | 仕様書の1節、あるいは1関所ぶんのコードや判定 | 順序上の位置。git に関する一切 | `@openreachtech/hora` |
-| `hora-skills` | **すべての手順と、すべての合否基準** | それが呼ばれる時機 | `@openreachtech/hora-skills` |
+| 3つのスキルパッケージ | **すべての手順と、すべての合否基準** | それが呼ばれる時機 | `@openreachtech/hora-skills-ort-core`・`-ort-renchan`・`-ort-furo` |
 
 **4つのどれも、このリポジトリの中にはありません。** 4層すべてがパッケージとして届き、このリポジトリが持つのは仕様書と、これらの文書と、`.hora/` にある実行自身の記録です。
 
@@ -89,7 +89,7 @@ Hora Kit が仕様書をアプリケーションに変えるまで。何がど�
 
 **`hora-implementer` は git にも `.hora/` にも `specs/` にも触れません。** 1関所ぶん — または1関所の1単位ぶん — のコードとテストを書き、それ以外はすべて報告します。必要な依存、触ってはいけない共有ファイル、メインセッションに集約ファイルを再生成させたいフォルダ、変えたくなった contract、仕様書で見つけた問題です。[`/hora-build`](../.claude/skills/hora-build/SKILL.md) がその報告に基づいて動きます。
 
-**`hora-digester` は1つのファイルだけを書き、他はすべて読むだけです。** 出力は `.hora/digests/<skill-name>.md` で、ヘッダには由来した `hora-skills` のバージョンが入ります — だからダイジェストはインストール済みのバージョンと一致する間だけ使われ、パッケージが更新されれば、次に読まれる前に書き直されます。権威はスキル本体のままです。ダイジェストで解けない疑問が出た時点で、implementer が本体を開きます。
+**`hora-digester` は1つのファイルだけを書き、他はすべて読むだけです。** 出力は `.hora/digests/<skill-name>.md` で、ヘッダには由来したパッケージと、そのパッケージのバージョンが入ります — だからダイジェストはインストール済みのバージョンと一致する間だけ使われ、由来したパッケージが更新されれば、そのダイジェストは次に読まれる前に書き直されます。権威はスキル本体のままです。ダイジェストで解けない疑問が出た時点で、implementer が本体を開きます。
 
 **エージェントをここまで縛る理由：** 禁止の一つひとつが、「2人の書き手が衝突する経路」か「誰にも見えないところで決定が下される経路」を1本ずつ塞いでいます。
 
@@ -103,7 +103,7 @@ Hora Kit が仕様書をアプリケーションに変えるまで。何がど�
 .hora/
   tree/<repository>.md          /hora-setup が実地に読んだ内容と、読んだ時点のタグ
   digests/<skill-name>.md       equip 済みスキル1つの規約を短くしたもの。由来した
-                                hora-skills のバージョン付き
+                                由来したパッケージとバージョン付き
   spec/<version>/_stages.md     /hora-spec 自身の、どこまで進んだかの記録（第2部）
   spec/<version>/_assets.md     ステージ0 が何を、どこから、どのコミット時点で読んだか
   spec/<version>/_divergence.md 文書とコードの食い違い — 1件につき1行、各行はその
@@ -119,7 +119,9 @@ Hora Kit が仕様書をアプリケーションに変えるまで。何がど�
   glossary.md                   追記のみ。版で分けない
 
   equip-core.json               hora-core の install が置いたもの。gitignore 対象
-  equip-skills.json             hora-skills の install が置いたもの。gitignore 対象
+  hora-skills-ort-core.json     各スキルパッケージの install が置いたもの。
+  hora-skills-ort-furo.json     パッケージごとに1ファイル。gitignore 対象
+  hora-skills-ort-renchan.json
 ```
 
 `git log .hora/` が「何が走ったか」の履歴です。他に記録している場所はなく、必要もありません。

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -33,14 +33,14 @@ This document explains the design. It is not the authority on any rule — each 
 
 ## Four layers
 
-![Four layers: /hora, the five skills, the stage skills and the two agents, and hora-skills](./images/layers.svg)
+![Four layers: /hora, the five skills, the stage skills and the two agents, and the three skills packages](./images/layers.svg)
 
 | Layer | What it decides | What it never decides | Ships in |
 |---|---|---|---|
 | `/hora` | which phase comes next; every branch, commit and merge | anything about the work itself | `@openreachtech/hora` |
 | the five skills | the order of the work, and each gate's exit condition | how any of it is written | `@openreachtech/hora` |
 | the stage skills and the two agents | one section of the spec, or one checkpoint's code or verdict | where they run in the order; anything about git | `@openreachtech/hora` |
-| `hora-skills` | **every procedure and every pass/fail criterion** | when it is invoked | `@openreachtech/hora-skills` |
+| the three skills packages | **every procedure and every pass/fail criterion** | when it is invoked | `@openreachtech/hora-skills-ort-core`, `-ort-renchan`, `-ort-furo` |
 
 **Not one of the four is in this repository.** All four arrive as packages, and what this repository holds is the spec, these documents, and the run's own record under `.hora/`.
 
@@ -89,7 +89,7 @@ Not everything can be delegated to a subagent, and the line is not about difficu
 
 **`hora-implementer` never touches git, `.hora/`, or `specs/`.** It writes code and tests for one checkpoint — or for one unit of one — and reports everything else: a dependency it needs, a shared file it must not edit, the folder whose aggregation file the main session should regenerate, a contract it wanted to change, a problem it found in the spec. [`/hora-build`](../.claude/skills/hora-build/SKILL.md) acts on the report.
 
-**`hora-digester` writes one file and reads everything else.** Its output is `.hora/digests/<skill-name>.md`, and the header names the `hora-skills` version it was derived from — so a digest is used only while it matches what is installed, and a package update leaves each one to be rewritten before it is read again. The skill itself stays the authority: an implementer opens it the moment its digest leaves a question open.
+**`hora-digester` writes one file and reads everything else.** Its output is `.hora/digests/<skill-name>.md`, and the header names the package it was derived from and that package's version — so a digest is used only while it matches what is installed, and an update of the package it came from leaves each of its digests to be rewritten before any is read again. The skill itself stays the authority: an implementer opens it the moment its digest leaves a question open.
 
 **Why the agents are so tightly bounded:** every one of those prohibitions removes a way for two writers to collide, or for a decision to be made where nobody can see it.
 
@@ -103,7 +103,7 @@ There is no state file. **The state is `.hora/`, and its checkboxes are the stat
 .hora/
   tree/<repository>.md          what /hora-setup read in the real tree, and the tag it read it at
   digests/<skill-name>.md       one equipped skill's conventions in short form, and the
-                                hora-skills version they came from
+                                package and version they came from
   spec/<version>/_stages.md     /hora-spec's own record of where it got to (Part 2)
   spec/<version>/_assets.md     what stage 0 read, where from, and at what commit
   spec/<version>/_divergence.md where the documents and the code disagree — one row
@@ -121,7 +121,9 @@ There is no state file. **The state is `.hora/`, and its checkboxes are the stat
   glossary.md                   append-only, not split per version
 
   equip-core.json               what the last hora-core install placed. Gitignored
-  equip-skills.json             what the last hora-skills install placed. Gitignored
+  hora-skills-ort-core.json     what the last install of each skills package placed —
+  hora-skills-ort-furo.json     one record per package. Gitignored
+  hora-skills-ort-renchan.json
 ```
 
 `git log .hora/` is the history of what ran. Nothing else records it, and nothing needs to.

--- a/docs/skills.ja.md
+++ b/docs/skills.ja.md
@@ -2,7 +2,7 @@
 
 # Hora Kit が乗っているスキル群
 
-Hora Kit が持っているのは順序と関所です。**手順と合否基準はすべて別の場所** — [`@openreachtech/hora-skills`](https://github.com/openreachtech/hora-skills) パッケージにあります。
+Hora Kit が持っているのは順序と関所です。**手順と合否基準はすべて別の場所** — ドメインごとに分かれた3つのスキルパッケージ [`hora-skills-ort-core`](https://github.com/openreachtech/hora-skills-ort-core)・[`hora-skills-ort-renchan`](https://github.com/openreachtech/hora-skills-ort-renchan)・[`hora-skills-ort-furo`](https://github.com/openreachtech/hora-skills-ort-furo) にあります。
 
 このドキュメントはその境界の話です。なぜ在るのか、スキルはどうやってセッションに届くのか、どう参照するのか、無かったときどうなるのか。
 
@@ -13,7 +13,7 @@ Hora Kit が持っているのは順序と関所です。**手順と合否基準
 同じ規約を書いた文書が2つあれば、必ず食い違います。**問題は「いつ」と「誰かが気づくか」だけです。**
 
 ```
-hora-skills       「stub 実装は server/<area>/<audience>/stub/ に置く」
+hora-skills-ort-* 「stub 実装は server/<area>/<audience>/stub/ に置く」
                        │
                        │  パッケージが更新される。パスが変わる。
                        ▼
@@ -26,7 +26,7 @@ Hora Kit          「stub 実装は server/<area>/<audience>/stub/ に置く」
 
 したがって Hora Kit の規則は絶対です。
 
-> **`hora-skills` のスキルが既に持っている手順・規約・合否基準を、hora skill 側に書いてはならない。「何をする作業か」を書いて委譲すること。**
+> **`hora-skills-ort-*` パッケージのスキルが既に持っている手順・規約・合否基準を、hora skill 側に書いてはならない。「何をする作業か」を書いて委譲すること。**
 
 これは `/hora-setup` が boilerplate に対して既に採っている考え方と同じです：**実物を読め。今そう書いてあることを焼き込むな。** ここでの実物はパッケージです。
 
@@ -35,7 +35,7 @@ Hora Kit          「stub 実装は server/<area>/<audience>/stub/ に置く」
 | | 所有するもの | 例 |
 |---|---|---|
 | **Hora Kit** | 何がいつ起きるか。次に進む前に何が真でなければならないか | *「関所4は、この機能が足す全操作にスキーマ準拠の stub が存在したら通過」* |
-| **`hora-skills`** | どうやるか。何をもって「ちゃんとできた」か | *「stub は `stub/{queries,mutations}/` に置き、スキーマを写し、DB アクセスを持たず、実装 resolver とクラス名を共有する」* |
+| **`hora-skills-ort-*` パッケージ** | どうやるか。何をもって「ちゃんとできた」か | *「stub は `stub/{queries,mutations}/` に置き、スキーマを写し、DB アクセスを持たず、実装 resolver とクラス名を共有する」* |
 
 **2つの文は重なりません。** それが判定基準です — Hora Kit のある行が、パッケージと突き合わせて「食い違っている」と判定できてしまうなら、その行は Hora Kit にあるべきではありません。
 
@@ -48,24 +48,26 @@ Claude Code がスキルを見つけるのは、セッション自身の `.claud
 `npm install` が、このリポジトリ自身の `postinstall` を通してそのコピーを実行します。
 
 ```json
-"hora:init": "hora-core install && hora-skills install",
+"hora:init": "hora-core install && hora-skills-ort-core install && hora-skills-ort-renchan install && hora-skills-ort-furo install",
 "postinstall": "npm run hora:init"
 ```
 
 ```
 node_modules/@openreachtech/hora/dist/agents/<agent>.md   ─>  .claude/agents/<agent>.md
 node_modules/@openreachtech/hora/dist/skills/<skill>/     ─>  .claude/skills/<skill>/
-node_modules/@openreachtech/hora-skills/dist/skills/<skill>/  ─>  .claude/skills/<skill>/
+node_modules/@openreachtech/hora-skills-ort-core/dist/skills/<skill>/     ─>  .claude/skills/<skill>/
+node_modules/@openreachtech/hora-skills-ort-renchan/dist/skills/<skill>/  ─>  .claude/skills/<skill>/
+node_modules/@openreachtech/hora-skills-ort-furo/dist/skills/<skill>/     ─>  .claude/skills/<skill>/
                           そのままコピー。改名も書き換えもしない
 ```
 
-- **パッケージ2つ、ペイロード2種、行き先は1つ。** `@openreachtech/hora` が hora の skill と agent を運び（`/hora` 自身もその1つです）、`@openreachtech/hora-skills` がそれらの委譲先である手順を運びます。どちらも平坦な1つの `.claude/skills/` に並んで着地します。`hb-`/`hf-`/`hc-` の接頭辞はそのためにあります
+- **パッケージ4つ、ペイロード2種、行き先は1つ。** `@openreachtech/hora` が hora の skill と agent を運び（`/hora` 自身もその1つです）、3つの `hora-skills-ort-*` パッケージがそれらの委譲先である手順を、ドメインごとに1パッケージずつ運びます。いずれも平坦な1つの `.claude/skills/` に並んで着地します。`hoc-`/`hor-`/`hof-` の接頭辞はそのためにあります
 - **`npm install` だけで足ります。** 引数なしの `npm install` はフックを再実行するので、更新されたパッケージも追随します。コマンドラインでパッケージを名指しした場合は再実行されないため、そのときは `npm run hora:init` で配り直します
-- **各コマンドは再実行可能です。** 自分の前回の実行が入れたもの（`.hora/equip-core.json` と `.hora/equip-skills.json` に記録）と、自分が配る名前を持つものを先に削除してから、新しくコピーします。パッケージが改名・削除したスキルは残留せず、このリポジトリが自分で書いたスキルには触れません
-- **リポジトリの clone を待ちません。** 両パッケージはこのリポジトリ自身の devDependencies なので、ここで `npm install` が済んでいれば使えます
+- **各コマンドは再実行可能です。** 自分の前回の実行が入れたもの（`hora-core` は `.hora/equip-core.json`、3つのスキルパッケージはそれぞれ `.hora/<パッケージ名>.json` に記録）と、自分が配る名前を持つものを先に削除してから、新しくコピーします。パッケージが改名・削除したスキルは残留せず、このリポジトリが自分で書いたスキルには触れません
+- **リポジトリの clone を待ちません。** 4つのパッケージはいずれもこのリポジトリ自身の devDependencies なので、ここで `npm install` が済んでいれば使えます
 - **コピーは gitignore 済みで、ルートの lint からも除外されています。** どちらも `.claude/agents/` と `.claude/skills/` の全体を無視した上で、このリポジトリ自身のものを1つずつ名指しで戻す形です。名前パターンではなく許可リストなのは後述の理由によります。生成物であって、ここで書いたものではありません
 
-**配置されるのはこの2つで、3つ目は置かれた場所のまま読まれます。** **`@openreachtech/hora-ecosystem`** — 同じくこのリポジトリの devDependency で、関所5が「新しく書く前に」確認する社内パッケージのカタログです。どこにも配置されず、`node_modules/` の中でそのまま読まれます。レイアウトはパッケージ自身が自由に変えるものです（[`checkpoints.md`](../.claude/skills/hora-build/references/checkpoints.md) の関所5）。
+**配置されるのはこの4つで、もう1つは置かれた場所のまま読まれます。** **`@openreachtech/hora-ecosystem`** — 同じくこのリポジトリの devDependency で、関所5が「新しく書く前に」確認する社内パッケージのカタログです。どこにも配置されず、`node_modules/` の中でそのまま読まれます。レイアウトはパッケージ自身が自由に変えるものです（[`checkpoints.md`](../.claude/skills/hora-build/references/checkpoints.md) の関所5）。
 
 ---
 
@@ -121,21 +123,21 @@ Hora Kit    「<かつての名前> に委譲せよ」
 
 | 接頭辞 | ドメイン | 対象 |
 |---|---|---|
-| `hb-` | `backend` | バックエンドリポジトリ |
-| `hf-` | `frontend` | フロントエンドリポジトリ |
-| `hc-` | `core` | どちらでも |
+| `hor-` | `backend` | バックエンドリポジトリ |
+| `hof-` | `frontend` | フロントエンドリポジトリ |
+| `hoc-` | `core` | どちらでも |
 
-ドメインは `hora-skills` 自身のもので、その一部だけを入れることもできます — フロントエンドが無いプロジェクトなら `npx --no hora-skills install --domains core,backend`、あるいは同じ指定を package.json の `horaSkills` に一度書いておく形です。**`--no` は、ダウンロードの前で npx を止めます** — 名前の解決はレジストリに問い合わせますが、取得はしないので、他人のパッケージの install スクリプトも bin も走りません。これが無いと、bin が入っていない状態は、その無スコープ名で公開されたものの取得になります。
+ドメインごとにパッケージが分かれています（`hora-skills-ort-core`・`hora-skills-ort-renchan`・`hora-skills-ort-furo`）。したがって **ドメインの選択は、入れるパッケージの選択そのものです。** フロントエンドが無いプロジェクトは `-ort-furo` を devDependencies と `hora:init` から外すだけで、渡すオプションも package.json に書く指定もありません。各パッケージは自分のペイロードだけを配り、自分の記録が名指すものだけを削除するので、後から1つ外せばそのスキルだけが消え、他には触れません。
 
-**`hc-` は `core` ドメインであって、`hora-core` パッケージではありません。** ここでは両方の名前が出てきますが、指すものが違います。`hora-core` は `@openreachtech/hora` を配置するコマンドで、そのパッケージは `hc-` スキルを1つも配りません。
+**`hoc-` は `core` ドメインであって、`hora-core` コマンドではありません。** ここでは両方の名前が出てきますが、指すものが違います。`hora-core` が配置するのは `@openreachtech/hora` で、そのパッケージは `hoc-` スキルを1つも配りません。`hoc-` スキルはすべて `hora-skills-ort-core` から来ます。
 
-どの面に仕えるスキルかは、その先を読む前に分かります。**接頭辞の後ろはラベルであって、分類ではありません** — このパッケージには、フロントエンドアプリの操作クライアントを扱うスキルと、バックエンドサーバーの API スキーマを扱うスキルがあり、名前の違いは単語1つ分しかありません。**どちらがどちらかを言えるのは description だけ**で、名前の語感で選ぶのは間違ったスキルが呼ばれる典型です。
+どの面に仕えるスキルかは、その先を読む前に分かります。**接頭辞の後ろはラベルであって、分類ではありません** — フロントエンドアプリの操作クライアントを扱うスキルと、バックエンドサーバーの API スキーマを扱うスキルがあり、名前の違いは単語1つ分しかありません。**どちらがどちらかを言えるのは description だけ**で、名前の語感で選ぶのは間違ったスキルが呼ばれる典型です。
 
-上の除外リストが `hb-*`/`hf-*`/`hc-*` のパターンではなく許可リストなのも同じ理由です — マッチしなくなった拒否リストは、そうなったことを何も言いません。
+上の除外リストが `hor-*`/`hof-*`/`hoc-*` のパターンではなく許可リストなのも同じ理由です — マッチしなくなった拒否リストは、そうなったことを何も言いません。
 
 ---
 
-## パッケージが覆っている範囲
+## これらのパッケージが覆っている範囲
 
 **これは見取り図であって、目録ではありません。** 権威ある一覧は、配備後の `.claude/skills/` が持っているものです。
 
@@ -145,7 +147,7 @@ ls .claude/skills/
 
 そして「関所 → 委譲するスキル」の権威ある対応は [`checkpoints.md`](../.claude/skills/hora-build/references/checkpoints.md)、「仕様ステージ → 委譲するスキル」は [`stages.md`](../.claude/skills/hora-spec/references/stages.md) です。**どちらも意図的にここには再掲しません** — あの表の2つ目の写しは、まさにこのドキュメント全体が扱っている食い違いそのものになります。
 
-### `hb-` — バックエンド
+### `hor-` — バックエンド
 
 | 領域 | 覆う範囲 |
 |---|---|
@@ -160,7 +162,7 @@ ls .claude/skills/
 | **セキュリティ** | リポジトリ全体の read-only 監査。指摘を出すだけで何も直さない |
 | **テスト** | テストの置き場所、実行順の保証、ローカル E2E コンテナ群 |
 
-### `hf-` — フロントエンド
+### `hof-` — フロントエンド
 
 | 領域 | 覆う範囲 |
 |---|---|
@@ -172,7 +174,7 @@ ls .claude/skills/
 | **UI/UX** | プロジェクト context ファイル、構造的に正しい UI の生成、既存出力の監査 |
 | **検収** | **受入レビュー**と、恒久的な E2E シナリオ仕様 |
 
-### `hc-` — コア（どちらの面でも）
+### `hoc-` — コア（どちらの面でも）
 
 | 領域 | 覆う範囲 |
 |---|---|

--- a/docs/skills.md
+++ b/docs/skills.md
@@ -2,7 +2,7 @@
 
 # The skills Hora Kit runs on
 
-Hora Kit holds the order and the gates. **Every procedure, and every pass/fail criterion, comes from somewhere else** — the [`@openreachtech/hora-skills`](https://github.com/openreachtech/hora-skills) package.
+Hora Kit holds the order and the gates. **Every procedure, and every pass/fail criterion, comes from somewhere else** — the three skill packages: [`hora-skills-ort-core`](https://github.com/openreachtech/hora-skills-ort-core), [`hora-skills-ort-renchan`](https://github.com/openreachtech/hora-skills-ort-renchan) and [`hora-skills-ort-furo`](https://github.com/openreachtech/hora-skills-ort-furo), one per domain.
 
 This document is about that boundary: why it exists, how the skills reach the session, how they are referred to, and what happens when one is missing.
 
@@ -13,7 +13,7 @@ This document is about that boundary: why it exists, how the skills reach the se
 Two documents describing the same convention will disagree. **The question is only when, and whether anybody notices.**
 
 ```
-hora-skills       "a stub implementation lives under server/<area>/<audience>/stub/"
+hora-skills-ort-* "a stub implementation lives under server/<area>/<audience>/stub/"
                        │
                        │  the package is updated. The path changes.
                        ▼
@@ -26,7 +26,7 @@ Hora Kit          "a stub implementation lives under server/<area>/<audience>/st
 
 So Hora Kit's rule is absolute:
 
-> **Never write a procedure, a convention or a pass/fail criterion into a hora skill when a skill in `hora-skills` already holds it. State the work and delegate it.**
+> **Never write a procedure, a convention or a pass/fail criterion into a hora skill when a skill in the `hora-skills-ort-*` packages already holds it. State the work and delegate it.**
 
 This is the same reasoning `/hora-setup` already applies to the boilerplates: **read the real thing; do not bake in what it currently says.** The package is the real thing here.
 
@@ -35,7 +35,7 @@ This is the same reasoning `/hora-setup` already applies to the boilerplates: **
 | | Owns | Example |
 |---|---|---|
 | **Hora Kit** | when something happens, and what must be true before the next thing may | *"Checkpoint 4 passes when a schema-accurate stub exists for every operation this feature adds"* |
-| **`hora-skills`** | how to do it, and what counts as done properly | *"a stub lives under `stub/{queries,mutations}/`, mirrors the schema, holds no DB access, and shares its class name with the real resolver"* |
+| **the `hora-skills-ort-*` packages** | how to do it, and what counts as done properly | *"a stub lives under `stub/{queries,mutations}/`, mirrors the schema, holds no DB access, and shares its class name with the real resolver"* |
 
 **The two sentences do not overlap.** That is the test: if a line in Hora Kit could be checked against the package and found to disagree, it does not belong in Hora Kit.
 
@@ -48,24 +48,26 @@ Claude Code discovers skills only in the session's own `.claude/skills/`. A pack
 `npm install` runs the copy, through this repository's own `postinstall`:
 
 ```json
-"hora:init": "hora-core install && hora-skills install",
+"hora:init": "hora-core install && hora-skills-ort-core install && hora-skills-ort-renchan install && hora-skills-ort-furo install",
 "postinstall": "npm run hora:init"
 ```
 
 ```
 node_modules/@openreachtech/hora/dist/agents/<agent>.md   ─>  .claude/agents/<agent>.md
 node_modules/@openreachtech/hora/dist/skills/<skill>/     ─>  .claude/skills/<skill>/
-node_modules/@openreachtech/hora-skills/dist/skills/<skill>/  ─>  .claude/skills/<skill>/
+node_modules/@openreachtech/hora-skills-ort-core/dist/skills/<skill>/     ─>  .claude/skills/<skill>/
+node_modules/@openreachtech/hora-skills-ort-renchan/dist/skills/<skill>/  ─>  .claude/skills/<skill>/
+node_modules/@openreachtech/hora-skills-ort-furo/dist/skills/<skill>/     ─>  .claude/skills/<skill>/
                           straight copy, no renaming, no rewriting
 ```
 
-- **Two packages, two payloads, one destination.** `@openreachtech/hora` carries the hora skills and the agents — `/hora` itself is one of them — and `@openreachtech/hora-skills` carries the procedures they delegate to. They land side by side in one flat `.claude/skills/`, which is what the `hb-`/`hf-`/`hc-` prefix is for
+- **Four packages, two payloads, one destination.** `@openreachtech/hora` carries the hora skills and the agents — `/hora` itself is one of them — and the three `hora-skills-ort-*` packages carry the procedures they delegate to, one package per domain. They land side by side in one flat `.claude/skills/`, which is what the `hoc-`/`hor-`/`hof-` prefix is for
 - **`npm install` alone is enough**, and a plain `npm install` with no arguments re-runs the hook, so an updated package follows along. Naming a package on the command line does not, so `npm run hora:init` re-equips on demand
-- **Each command is repeatable.** It removes what its own previous run installed — recorded in `.hora/equip-core.json` and `.hora/equip-skills.json` — along with anything named after an entry it distributes, before copying fresh. A skill a package renamed or dropped does not linger as a match candidate, and a skill your own repository authored is left alone
-- **It does not wait for any repository to be cloned.** Both packages are this repository's own devDependencies, so they are ready as soon as `npm install` has run here
+- **Each command is repeatable.** It removes what its own previous run installed — recorded in `.hora/equip-core.json` for `hora-core`, and in `.hora/<package name>.json` for each of the three skill packages — along with anything named after an entry it distributes, before copying fresh. A skill a package renamed or dropped does not linger as a match candidate, and a skill your own repository authored is left alone
+- **It does not wait for any repository to be cloned.** All four packages are this repository's own devDependencies, so they are ready as soon as `npm install` has run here
 - **The copies are gitignored, and excluded from the root lint.** Both do it by ignoring the whole of `.claude/agents/` and `.claude/skills/` and naming this repository's own entries back in, one by one — an allowlist, not a name pattern, for the reason below. They are regenerated, not authored here
 
-**Those two are equipped. A third package is read where it lies:** **`@openreachtech/hora-ecosystem`** — also a devDependency here — the catalog of in-house packages that checkpoint 5 checks before anything is written new. It is never equipped anywhere: it is read in place under `node_modules/`, and its layout is its own to change ([`checkpoints.md`](../.claude/skills/hora-build/references/checkpoints.md), checkpoint 5).
+**Those four are equipped. One more package is read where it lies:** **`@openreachtech/hora-ecosystem`** — also a devDependency here — the catalog of in-house packages that checkpoint 5 checks before anything is written new. It is never equipped anywhere: it is read in place under `node_modules/`, and its layout is its own to change ([`checkpoints.md`](../.claude/skills/hora-build/references/checkpoints.md), checkpoint 5).
 
 ---
 
@@ -121,21 +123,21 @@ The main session is handed the equipped skills' descriptions as part of its own 
 
 | Prefix | Domain | Applies to |
 |---|---|---|
-| `hb-` | `backend` | the backend repository |
-| `hf-` | `frontend` | a frontend repository |
-| `hc-` | `core` | either |
+| `hor-` | `backend` | the backend repository |
+| `hof-` | `frontend` | a frontend repository |
+| `hoc-` | `core` | either |
 
-The domain is `hora-skills`' own, and a repository can install a subset of them — `npx --no hora-skills install --domains core,backend` on a project with no frontend, or the same list declared once under `horaSkills` in package.json. **`--no` stops npx before it downloads**: the name is still resolved against the registry, but nothing is fetched, so neither the install script nor the bin of a stranger's package ever runs. Without it, a bin that is not installed becomes a fetch of whatever has been published under that unscoped name.
+Each domain is a package of its own — `hora-skills-ort-core`, `hora-skills-ort-renchan`, `hora-skills-ort-furo` — so **a repository selects domains by selecting packages.** A project with no frontend leaves `-ort-furo` out of its devDependencies and out of `hora:init`; there is no option to pass and nothing to declare in package.json. Each package installs only its own payload and removes only what its own record names, so leaving one out later takes its skills with it and touches none of the others.
 
-**`hc-` is the `core` domain, not the `hora-core` package.** Both names are in play here and they name different things: `hora-core` is the command that installs `@openreachtech/hora`, which distributes no `hc-` skill at all.
+**`hoc-` is the `core` domain, not the `hora-core` command.** Both names are in play here and they name different things: `hora-core` installs `@openreachtech/hora`, which distributes no `hoc-` skill at all — every `hoc-` skill comes from `hora-skills-ort-core`.
 
-So which surface a skill serves is visible before anything else. **Everything after the prefix is a label, not a classification** — one skill in this package covers operation clients in the frontend app and another covers API schemas for the backend server, and their names differ by no more than a word. **The description is the only thing that says which is which**, and matching on what a name sounds like is how the wrong one gets invoked.
+So which surface a skill serves is visible before anything else. **Everything after the prefix is a label, not a classification** — one skill covers operation clients in the frontend app and another covers API schemas for the backend server, and their names differ by no more than a word. **The description is the only thing that says which is which**, and matching on what a name sounds like is how the wrong one gets invoked.
 
-This is also why the exclusion lists above are allowlists rather than `hb-*`/`hf-*`/`hc-*` patterns: a denylist that stops matching says nothing when it stops.
+This is also why the exclusion lists above are allowlists rather than `hor-*`/`hof-*`/`hoc-*` patterns: a denylist that stops matching says nothing when it stops.
 
 ---
 
-## What the package covers
+## What the packages cover
 
 **This is an orientation, not an inventory.** The authoritative list is whatever `.claude/skills/` holds after equipping:
 
@@ -145,7 +147,7 @@ ls .claude/skills/
 
 And the authoritative statement of **what work** each checkpoint delegates is [`checkpoints.md`](../.claude/skills/hora-build/references/checkpoints.md); for a spec stage it is [`stages.md`](../.claude/skills/hora-spec/references/stages.md). **Neither is repeated here, deliberately** — a second copy of either would be exactly the drift this whole document is about.
 
-### `hb-` — backend
+### `hor-` — backend
 
 | Area | Covers |
 |---|---|
@@ -160,7 +162,7 @@ And the authoritative statement of **what work** each checkpoint delegates is [`
 | **Security** | a read-only, repo-wide audit that produces findings and fixes nothing |
 | **Testing** | where a test goes, how its run order is guaranteed, and the local E2E container stack |
 
-### `hf-` — frontend
+### `hof-` — frontend
 
 | Area | Covers |
 |---|---|
@@ -172,7 +174,7 @@ And the authoritative statement of **what work** each checkpoint delegates is [`
 | **UI/UX** | the project context file, generating UI that is correct by construction, and auditing existing output |
 | **Acceptance** | **the acceptance review**, and the durable end-to-end scenario specification |
 
-### `hc-` — core (either surface)
+### `hoc-` — core (either surface)
 
 | Area | Covers |
 |---|---|

--- a/docs/writing-style.ja.md
+++ b/docs/writing-style.ja.md
@@ -6,7 +6,7 @@
 
 この文書は、それらのファイルが従う文体です。書き方の話であって、規則の中身の話ではありません。
 
-**ここで書かれるものではありません。** hora の skill と agent は [`hora-core`](https://github.com/openreachtech/hora-core) で、それらの委譲先である手順は [`hora-skills`](https://github.com/openreachtech/hora-skills) で書かれます。このリポジトリはそれを `.claude/` に受け取るだけです。文体は方法論と同じ場所に置く、という理由でここにあります。
+**ここで書かれるものではありません。** hora の skill と agent は [`hora-core`](https://github.com/openreachtech/hora-core) で、それらの委譲先である手順は、そのドメインのスキルパッケージ [`hora-skills-ort-core`](https://github.com/openreachtech/hora-skills-ort-core)・[`hora-skills-ort-renchan`](https://github.com/openreachtech/hora-skills-ort-renchan)・[`hora-skills-ort-furo`](https://github.com/openreachtech/hora-skills-ort-furo) で書かれます。このリポジトリはそれを `.claude/` に受け取るだけです。文体は方法論と同じ場所に置く、という理由でここにあります。
 
 ---
 

--- a/docs/writing-style.md
+++ b/docs/writing-style.md
@@ -6,7 +6,7 @@ Every file the two hora packages distribute — every skill and every agent — 
 
 This document is the style those files are held to. It is about wording, never about what the rules say.
 
-**They are not authored here.** The hora skills and agents are written in [`hora-core`](https://github.com/openreachtech/hora-core), the procedures they delegate to in [`hora-skills`](https://github.com/openreachtech/hora-skills); this repository only receives them, under `.claude/`. The style lives with the method, which is documented here.
+**They are not authored here.** The hora skills and agents are written in [`hora-core`](https://github.com/openreachtech/hora-core), the procedures they delegate to in the skills package of their domain — [`hora-skills-ort-core`](https://github.com/openreachtech/hora-skills-ort-core), [`hora-skills-ort-renchan`](https://github.com/openreachtech/hora-skills-ort-renchan) or [`hora-skills-ort-furo`](https://github.com/openreachtech/hora-skills-ort-furo); this repository only receives them, under `.claude/`. The style lives with the method, which is documented here.
 
 ---
 


### PR DESCRIPTION
# Why

* Close #118

# How

* `docs/skills*`: names the three packages, renames every prefix to `hoc-` / `hor-` / `hof-`, and **drops the domain option** — there is no `--domains` and no `horaSkills` in package.json since the split, so a repository selects domains by selecting packages. `hora:init` equips four packages, and each keeps its own record at `.hora/<package name>.json`
* `docs/architecture*`: the fourth layer is three packages, and a digest header names the package it came from beside the version — the same change the kit itself took in #113
* `docs/writing-style*`: a procedure is written in the skills package of its domain
* `.claude/skills/flatten/SKILL.md`: the name is borrowed from those packages, each of which now holds a single domain directory; `bank-id` is bound for `hora-skills-ort-renchan` as `hor-bank-id`

The two `layers*.svg` diagrams follow in their own pull request.
