### PR TITLE
📄 Retake the opening of the writing style document

### DIFF
--- a/docs/writing-style.ja.md
+++ b/docs/writing-style.ja.md
@@ -6,7 +6,7 @@
 
 この文書は、それらのファイルが従う文体です。書き方の話であって、規則の中身の話ではありません。
 
-**ここで書かれるものではありません。** hora の skill と agent は [`hora-core`](https://github.com/openreachtech/hora-core) で、それらの委譲先である手順は、そのドメインのスキルパッケージ [`hora-skills-ort-core`](https://github.com/openreachtech/hora-skills-ort-core)・[`hora-skills-ort-renchan`](https://github.com/openreachtech/hora-skills-ort-renchan)・[`hora-skills-ort-furo`](https://github.com/openreachtech/hora-skills-ort-furo)・[`hora-skills-ort-support`](https://github.com/openreachtech/hora-skills-ort-support) で書かれます。このリポジトリはそれを `.claude/` に受け取るだけです。文体は方法論と同じ場所に置く、という理由でここにあります。
+**hora の skill と agent は、ここで書かれます。** それらの委譲先である手順は、そのドメインのスキルパッケージ（ドメインごとに1つ、それぞれが自分のカタログを持つ）で書かれます。このページは、ここで書かれるものが従う文体です。文体は方法論と同じ場所に置く、という理由でここにあります。
 
 ---
 

--- a/docs/writing-style.md
+++ b/docs/writing-style.md
@@ -6,7 +6,7 @@ Every file the two hora packages distribute — every skill and every agent — 
 
 This document is the style those files are held to. It is about wording, never about what the rules say.
 
-**They are not authored here.** The hora skills and agents are written in [`hora-core`](https://github.com/openreachtech/hora-core), the procedures they delegate to in the skills package of their domain — [`hora-skills-ort-core`](https://github.com/openreachtech/hora-skills-ort-core), [`hora-skills-ort-renchan`](https://github.com/openreachtech/hora-skills-ort-renchan) or [`hora-skills-ort-furo`](https://github.com/openreachtech/hora-skills-ort-furo) or [`hora-skills-ort-support`](https://github.com/openreachtech/hora-skills-ort-support); this repository only receives them, under `.claude/`. The style lives with the method, which is documented here.
+**The hora skills and the agents are written here**, and the procedures they delegate to are written in the skills package of their domain — one package per domain, each carrying its own catalog. This page is the style the ones written here are held to, and it lives with the method for that reason.
 
 ---
 


### PR DESCRIPTION
# Why

* Close #140

# How

* **The sentence was false here.** It opened with `They are not authored here` — true of the boilerplate, which received a copy of this document, and wrong of this repository, where the hora skills and the agents are in fact written
* It also carried five links out of this repository: one to `hora-core` itself and one to each skills package. `core and skills are independent from any other repository; only boilerplate includes reference links of other repository`, so the packages are named without linking
* `docs/` in this repository now holds no reference to another repository at all
