### PR TITLE
📄 Register `/hora-hotfix` to documents

### DIFF
--- a/docs/adopting.ja.md
+++ b/docs/adopting.ja.md
@@ -431,6 +431,7 @@ Authority: as-built — what these repositories do is what 1.0.0 is
 |---|---|
 | 各コマンドの詳細 | [`commands.ja.md`](./commands.ja.md) |
 | なぜこの設計なのか | [`architecture.ja.md`](./architecture.ja.md) |
+| 緊急対応の経路（全体） | [`hotfix.ja.md`](./hotfix.ja.md) |
 | 関所が委譲するスキル群 | [`structure.md`](../kit/skills/hora/references/structure.md) |
 | 仕様書の書式 | [`spec-format.md`](../kit/skills/hora/references/spec-format.md) |
 | ステージ0と、仕様書を書く7つのステージ | [`stages.md`](../kit/skills/hora-spec/references/stages.md) |

--- a/docs/adopting.md
+++ b/docs/adopting.md
@@ -435,6 +435,7 @@ The workflows under `.github/workflows/` follow the repository's visibility: a p
 |---|---|
 | what each command does, in detail | [`commands.md`](./commands.md) |
 | why the design is shaped this way | [`architecture.md`](./architecture.md) |
+| the emergency route, end to end | [`hotfix.md`](./hotfix.md) |
 | the skills the checkpoints delegate to | [`structure.md`](../kit/skills/hora/references/structure.md) |
 | the format of a spec | [`spec-format.md`](../kit/skills/hora/references/spec-format.md) |
 | stage 0, then the seven stages a spec is written through | [`stages.md`](../kit/skills/hora-spec/references/stages.md) |


### PR DESCRIPTION
# Why

* Close #125

# How

* `/hora-hotfix` is documented: it has its own section in `commands*`, a page of its own in `hotfix*`, and a paragraph in `architecture*`. The one place it was missing is the `Where to go next` table of `adopting*` — `architecture*` and `commands*` both carry that row, and `adopting*` did not
* A reader arriving through the adoption route is exactly the one who will meet an emergency on a codebase that already exists, so that table is where the route has to be offered
