### PR TITLE
📄 Register `/hora-hotfix` beside the four layers

### DIFF
--- a/docs/architecture.ja.md
+++ b/docs/architecture.ja.md
@@ -42,6 +42,8 @@ Hora Kit が仕様書をアプリケーションに変えるまで。何がど�
 | ステージ skill と2つの agent | 仕様書の1節、あるいは1関所ぶんのコードや判定 | 順序上の位置。git に関する一切 | `@openreachtech/hora` |
 | 4つのスキルパッケージ | **すべての手順と、すべての合否基準** | それが呼ばれる時機 | `@openreachtech/hora-skills-ort-core`・`-ort-renchan`・`-ort-furo`・`-ort-support` |
 
+**4つの層のどれにも属さない skill が1つだけあり、それは `/hora` が決して起動しない唯一の skill です — `/hora-hotfix`。** 作業の順序も、関所の終了条件も決めません。何を緊急とするかは人が決めることだからです。直接呼ばれ、release ラインではなく `main` の上で動き、その結果の上に `/hora` が開いている release ライン群を rebase します。配布元は他と同じ `@openreachtech/hora` です。[`commands.ja.md`](./commands.ja.md) の `/hora-hotfix` と、経路全体を書いた [`hotfix.ja.md`](./hotfix.ja.md) を参照してください。
+
 **4つのどれも、このリポジトリの中にはありません。** 4層すべてがパッケージとして届き、このリポジトリが持つのは仕様書と、これらの文書と、`.hora/` にある実行自身の記録です。
 
 **驚かれるのは、パッケージ2つの間の分割です。** Hora Kit は resolver や migration やコンポーネントの書き方を一切持っていません。持ってはいけません — それらは独自にバージョン管理・更新されるパッケージにあります。Hora Kit 側に写しを置けば、そのパッケージが動いた瞬間に食い違い、しかも**食い違ったことを誰も知らせません。** [`structure.md`](../kit/skills/hora/references/structure.md) の "The division of labor" と [`structure.md`](../kit/skills/hora/references/structure.md) を参照してください。

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -42,6 +42,8 @@ This document explains the design. It is not the authority on any rule — each 
 | the stage skills and the two agents | one section of the spec, or one checkpoint's code or verdict | where they run in the order; anything about git | `@openreachtech/hora` |
 | the four skills packages | **every procedure and every pass/fail criterion** | when it is invoked | `@openreachtech/hora-skills-ort-core`, `-ort-renchan`, `-ort-furo`, `-ort-support` |
 
+**One skill sits outside all four, and it is the only one `/hora` never starts: `/hora-hotfix`.** It decides neither the order of the work nor a gate's exit condition, because whether something is an emergency is a person's call. It is invoked directly, it works on `main` rather than on a release line, and `/hora` rebases the open release lines onto what it produced. It ships in `@openreachtech/hora` like the rest. See [`commands.md`](./commands.md), `/hora-hotfix`, and [`hotfix.md`](./hotfix.md) for the whole route.
+
 **Not one of the four is in this repository.** All four arrive as packages, and what this repository holds is the spec, these documents, and the run's own record under `.hora/`.
 
 **The split between the two packages is the one that surprises people.** Hora Kit contains no instructions for writing a resolver, a migration or a component, and it must not — those live in a package that is versioned and updated on its own. A copy inside Hora Kit would disagree with the original the first time that package moved, and nothing would announce that it had. See [`structure.md`](../kit/skills/hora/references/structure.md), "The division of labor", and [`structure.md`](../kit/skills/hora/references/structure.md).


### PR DESCRIPTION
# Why

* Close #125

# How

* `architecture{,.ja}.md` counted five skills in its layer table and named `/hora-hotfix` nowhere until the git-model section, 170 lines later. A reader taking the inventory at face value learns of a sixth skill only by accident
* It is registered beside the table rather than inside it, because it decides neither of the things that row's layer decides — not the order of the work, and not a gate's exit condition. Whether something is an emergency is a person's call, and `/hora` never starts it
* **The four diagrams are left alone.** `layers`, `overview` and `reentrancy` draw the ordered pipeline, and a command that is deliberately outside that order does not belong in a picture of it; `git-model` draws what is cut from a release line, and a hotfix is the one trunk that is not
* Every other document below `docs/` already registers it: `commands{,.ja}.md` names it in its opening line and gives it a section, `hotfix{,.ja}.md` is the route end to end, and `adopting{,.ja}.md`, `architecture{,.ja}.md` and `commands{,.ja}.md` all link to that document
