### PR TITLE
📄 Bump the package version to `0.5.0`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@openreachtech/hora",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@openreachtech/hora",
-      "version": "0.4.0",
+      "version": "0.5.0",
       "license": "Apache-2.0",
       "bin": {
         "hora-core": "lib/equip/hora-core.js"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openreachtech/hora",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "description": "Hora Kit: a package that distributes AI skills, agents, and docs for AI-driven application development.",
   "type": "module",
   "files": [


### PR DESCRIPTION
# Why

* Close #150

# How

* `package.json` and the two root entries of `package-lock.json` go to `0.5.0`, and nothing else changes — the other two `0.4.0` in the lock belong to `node-int64` and `type-check`
* This is the last pull request on the line. Every other issue under #124 is closed, so the version is all that stood between this line and publishing
