### PR TITLE
Record what each checkpoint cost on its line in the feature file

### DIFF
--- a/kit/skills/hora-build/SKILL.md
+++ b/kit/skills/hora-build/SKILL.md
@@ -109,7 +109,8 @@ Report the decision in one line before starting work — "building #attendance, 
 9. Verify the exit condition actually holds — with hora-verifier for anything
    a reading of the code can settle, in conversation for the four gates that
    check against use cases. At 6 and 16, where step 8's suite is itself the
-   proof, the verifier is usually skipped (below)
+   proof, the verifier is usually skipped (below). Met or not, add this run
+   to the line's run record (below)
 10. Write [x] into the feature file. Commit at the gate boundary, not here
 11. Move to the next checkpoint
 ```
@@ -144,6 +145,25 @@ Report the decision in one line before starting work — "building #attendance, 
 **Record it even when nothing matched.** An empty list is the evidence that the gate ran without its conventions; no list at all is indistinguishable from a checkpoint nobody thought about. Report the gap by name in the closing report too.
 
 **Never let an agent do this matching.** An agent would pick differently on a rerun, and nothing downstream could say which set the first run used.
+
+### A checkpoint line's run record
+
+A checkpoint line carries a second comment at its end, holding what running the checkpoint cost. The first comment stays exactly as it is: `/hora-plan` reads `<!-- n/a: … -->` by its text.
+
+```markdown
+- [x] 6. Actual API  <!-- skills: …; digests: … --> <!-- cleared: 1; reopened-by: 9; agents: 4; agent-time: 840s; verify-time: 240s -->
+```
+
+| Field | Meaning |
+|---|---|
+| `cleared:` | how many times this line went back to `[ ]`. Omitted while it is 0 |
+| `reopened-by:` | who cleared it, in order |
+| `agents:` | how many hora-implementer and hora-verifier agents this line started, over every run |
+| `agent-time:` | seconds of wall clock from starting them to the last one returning, over every run |
+| `verify-time:` | the hora-verifier share of `agent-time:` |
+| `agent-tokens:`, `verify-tokens:` | the same split, only where the Agent tool reports tokens |
+
+**Add this run to it whether the checkpoint passed or not** — the moment step 9 has judged, or the moment the feature stops short of it. A checkpoint settled in conversation carries only `cleared:` and `reopened-by:`. The record survives whoever rewrites the line, and a clear adds to it (`../hora/references/structure.md`, "What lives in `.hora/`").
 
 ### Step 3 — the digest each matched skill is read through
 

--- a/kit/skills/hora/references/structure.md
+++ b/kit/skills/hora/references/structure.md
@@ -324,7 +324,9 @@ Q4  missing-authorization  blocking: yes
   tasks/<version>/
     _plan.md                    the feature order, and the acceptance tasks. /hora-plan writes it
     <feature-id>.md             one feature. /hora-plan creates it, checklist and all;
-                                /hora-build writes the checkboxes and the matched skills into it
+                                /hora-build writes the checkboxes, the matched skills and each
+                                checkpoint's run record into it. A run record survives whoever
+                                rewrites the line, and a clear adds cleared: and reopened-by: to it
   contracts/<version>/          one file per server whose consumer is elsewhere
   questions/<version>/open.md   append-only. Answered by editing specs/
   acceptance/<version>/


### PR DESCRIPTION
## What this does

Records what running each checkpoint cost, on the checkpoint's own line in the feature file, as a second HTML comment at the end of the line. This is the baseline for the next PR, which hands `hora-verifier` the change set instead of letting it search for it.

Nothing about verification changes here. No exit condition moves, no verifier is skipped, no step is removed.

## Fields

```markdown
- [x] 6. Actual API  <!-- skills: …; digests: … --> <!-- cleared: 1; reopened-by: 9; agents: 4; agent-time: 840s; verify-time: 240s -->
```

| Field | Meaning |
|---|---|
| `cleared:` | how many times the line went back to `[ ]`. Omitted while 0 |
| `reopened-by:` | who cleared it, in order |
| `agents:` | hora-implementer and hora-verifier agents started for this line, over every run |
| `agent-time:` | seconds of wall clock from starting them to the last one returning, over every run |
| `verify-time:` | the hora-verifier share of `agent-time:` |
| `agent-tokens:` `verify-tokens:` | the same split, only where the Agent tool reports tokens |

The record is a second comment so that the first one stays byte-identical. `/hora-plan` reads `<!-- n/a: built before Hora Kit was adopted -->` by its exact text.

## Where the rule lives

- `structure.md`, "What lives in `.hora/`" — the one sentence every skill reads first: a run record survives whoever rewrites the line, and a clear adds `cleared:` and `reopened-by:` to it. This is what reaches `/hora-plan` (reconcile, hotfix debt) and `/hora` (catch-up redo), neither of which reads `hora-build`'s SKILL.
- `hora-build/SKILL.md`, "A checkpoint line's run record" — the format, and when to add to it (at the end of every run, met or not).
- `hora-build/SKILL.md`, step 9 — the one clause that makes the write happen.

## What to read from it before the next PR

After a few features have run on this branch, compare `verify-time:` to `agent-time:` per checkpoint. If the verifier's share is small, the next PR is not worth doing and should be dropped.

## Known limits

- The main session's own consumption is not measured.
- A run entered from a fresh `/hora` invocation loses the cost of agents the previous invocation started.
- `/hora-plan` clearing `built:` marks leaves `cleared: 1` on lines that never ran.
- Wall clock includes API latency and whatever the main session did while agents ran. Tokens, where reported, are the steadier measure.
