### PR TITLE
Update package-lock.json after npm audit fix

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -861,9 +861,9 @@
       }
     },
     "node_modules/@istanbuljs/load-nyc-config/node_modules/js-yaml": {
-      "version": "3.15.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.1.tgz",
-      "integrity": "sha512-S99WuO3HlhO3XN41EtYUNl9zzXjoJx7QvmipxsJVxtCBT0YHEFy+iOJhjSvrmV12nYhWpZaM8lPHkJm0yUMbag==",
+      "version": "3.15.2",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.2.tgz",
+      "integrity": "sha512-6EuL879VkRA+1Cz578mKMiKvjPNEuk6+r1JaFzoSWejZmtf7xWbIyw1e3KkxlkzTIt9Taw6JBhEppG7utc1P+w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4358,9 +4358,9 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
-      "integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.2.tgz",
+      "integrity": "sha512-SFNOvSJ+Dgf/9An904Yx+CgSlIPCkIpao4qo51lpee25TIRejdH3rhR4EZMGoNx3/TP3O+wzWuiTFl4sqbltzA==",
       "dev": true,
       "funding": [
         {


### PR DESCRIPTION
## Why

- **`CI Test` fails on every PR since 2026-09-08.** The `npm audit` step in `test.yml` runs before `npm ci`, and [GHSA-2883-xcg3-v3hh](https://github.com/advisories/GHSA-2883-xcg3-v3hh) (js-yaml, high) was published that evening — after `release/0.8.0`'s last green run. #177 and #178 fail on it, and so would any other PR.
- **It is unrelated to any change under review.** Both copies of js-yaml are transitive devDependencies: `4.3.1` under `eslint → @eslint/eslintrc`, `3.15.1` under `jest → babel-plugin-istanbul → @istanbuljs/load-nyc-config`.

## How

- `npm audit fix`, on a branch cut from `release/0.8.0`. It moves js-yaml to `4.3.2` and `3.15.2` — the first patched versions the advisory names — and touches nothing else.
- `package-lock.json` is the only file changed: 6 lines in, 6 out. No declared dependency moves, so there is no `package.json` commit ahead of it.
- Commit message follows `commits.md`'s form for a lock file update.

## Verification

- `npm audit` — 0 vulnerabilities
- `npm test` — 23 suites, 882 tests
- `npm ls js-yaml` — `4.3.2` and `3.15.2`, in the same two places

## After merging

#178 and #177 need no rebase: a PR's CI runs on the merge of its head into `release/0.8.0`, so re-running their checks once this is in turns them green.