### PR TITLE
Bump package version to 0.8.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@openreachtech/hora",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@openreachtech/hora",
-      "version": "0.7.0",
+      "version": "0.8.0",
       "license": "Apache-2.0",
       "bin": {
         "hora-core": "lib/equip/hora-core.js"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openreachtech/hora",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "description": "Hora Kit: a package that distributes AI skills, agents, and docs for AI-driven application development.",
   "type": "module",
   "files": [


### PR DESCRIPTION
## Why

- **`package.json` still reads `0.7.0` on `release/0.8.0`.** `release.yml` will tag the merge into `main` as `0.8.0` from the branch name, and the package published from it would then carry a version one behind its tag.
- **The bump belongs inside the release branch, before the merge** — that is where 0.6.0 (#158's line) and 0.7.0 (#168) put it, so the tag and the published version have always agreed.

## How

- `package.json` — `"version": "0.8.0"`, one line, its own commit, as #168 did it.
- `package-lock.json` — the two `version` fields the lock carries for this package, brought to `0.8.0` by `npm install --package-lock-only`, in the commit `commits.md` names for a lock update. Nothing else in the lock moves.
- No code, no kit file, no document changes.

## Verification

- `grep '"version": "0.8.0"' package.json package-lock.json` — three lines, the root and the lock's two
- `npm test` unchanged — nothing under `kit/` or `lib/` is touched
